### PR TITLE
Don't requeue failed messages

### DIFF
--- a/lib/concord/subscriber.rb
+++ b/lib/concord/subscriber.rb
@@ -66,12 +66,7 @@ module Concord
       block.call(message.body)
     rescue => e
       logger.error("Error handling message #{message.id}: #{e}")
-      requeue_message(message)
-    end
-
-    def requeue_message(message)
-      logger.info "Requeuing message #{message.id}"
-      sqs.send_message(queue, message.body)
+      raise e
     end
 
     def delete_message(message)


### PR DESCRIPTION
@brandonc This removes the logic for requeuing a failed message onto the SQS queue.  The goes against the [visibility timeout](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html) implementation provided out of the box by SQS.  If we don't manually delete a message from the queue, it will automatically become available in the queue after the visibility timeout, meaning that it will be reprocessed again.
