### PR TITLE
Rename gem to circuitry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.bundle/
 /.idea/
+/.ruby-gemset
+/.ruby-version
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in concord.gemspec
+# Specify your gem's dependencies in circuitry.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Concord
+# Circuitry
 
 Notification pub/sub and message queue processing using Amazon
 [SNS](http://aws.amazon.com/sns/) & [SQS](http://aws.amazon.com/sqs/).
@@ -11,7 +11,7 @@ Notification pub/sub and message queue processing using Amazon
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'concord'
+gem 'circuitry'
 ```
 
 And then execute:
@@ -20,14 +20,14 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install concord
+    $ gem install circuitry
 
 ## Usage
 
-Concord is configured via its configuration object.
+Circuitry is configured via its configuration object.
 
 ```ruby
-Concord.config do |c|
+Circuitry.config do |c|
   c.access_key = 'YOUR_AWS_ACCESS_KEY'
   c.secret_key = 'YOUR_AWS_SECRET_KEY'
   c.region = 'us-east-1'
@@ -55,14 +55,14 @@ Available configuration options include:
 
 ### Publishing
 
-Publishing is done via the `Concord.publish` method.  It accepts a topic name
+Publishing is done via the `Circuitry.publish` method.  It accepts a topic name
 the represents the SNS topic along with any non-nil object, representing the data
 to be serialized.  Whatever object is called will have its `to_json` method
 called for serialization.
 
 ```ruby
 obj = { foo: 'foo', bar: 'bar' }
-Concord.publish('any-topic-name', obj)
+Circuitry.publish('any-topic-name', obj)
 ```
 
 The `publish` method also accepts options that impact instantiation of the
@@ -74,7 +74,7 @@ The `publish` method also accepts options that impact instantiation of the
 
 ```ruby
 obj = { foo: 'foo', bar: 'bar' }
-Concord.publish('my-topic-name', obj, async: true)
+Circuitry.publish('my-topic-name', obj, async: true)
 ```
 
 Alternatively, if your options hash will remain unchanged, you can build a single
@@ -82,18 +82,18 @@ Alternatively, if your options hash will remain unchanged, you can build a singl
 
 ```ruby
 options = { ... }
-publisher = Concord::Publisher.new(options)
+publisher = Circuitry::Publisher.new(options)
 publisher.publish('my-topic-name', obj)
 ```
 
 ### Subscribing
 
-Subscribing is done via the `Concord.subscribe` method.  It accepts an SQS queue
+Subscribing is done via the `Circuitry.subscribe` method.  It accepts an SQS queue
 URL and takes a block for processing each message.  This method performs
 synchronously by default, and as such does not return.
 
 ```ruby
-Concord.subscribe('https://sqs.REGION.amazonaws.com/ACCOUNT-ID/QUEUE-NAME') do |message, topic_name|
+Circuitry.subscribe('https://sqs.REGION.amazonaws.com/ACCOUNT-ID/QUEUE-NAME') do |message, topic_name|
   puts "Received #{topic_name} message: #{message.inspect}"
 end
 ```
@@ -111,7 +111,7 @@ The `subscribe` method also accepts options that impact instantiation of the
   (default: 10)
 
 ```ruby
-Concord.subscribe('https://...', async: true, wait_time: 60, batch_size: 20) do |message, topic_name|
+Circuitry.subscribe('https://...', async: true, wait_time: 60, batch_size: 20) do |message, topic_name|
   # ...
 end
 ```
@@ -121,7 +121,7 @@ Alternatively, if your options hash will remain unchanged, you can build a singl
 
 ```ruby
 options = { ... }
-subscriber = Concord::Subscriber.new(options)
+subscriber = Circuitry::Subscriber.new(options)
 subscriber.subscribe('https://...') do |message, topic_name|
   # ...
 end
@@ -139,7 +139,7 @@ asynchronous support:
 1. Forking is not supported on all platforms (e.g.: Windows and NetBSD 4),
    requiring that your implementation use synchronous requests in such
    circumstances.  You can determine if asynchronous requests will work by
-   calling `Concord.platform_supports_async?`.
+   calling `Circuitry.platform_supports_async?`.
 
 2. Forking results in resources being copied from the parent process to the child
    process.  In order to prevent database connection errors and the like, you
@@ -176,7 +176,7 @@ and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-1. Fork it ( https://github.com/kapost/concord/fork )
+1. Fork it ( https://github.com/kapost/circuitry/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "concord"
+require "circuitry"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/circuitry.gemspec
+++ b/circuitry.gemspec
@@ -1,17 +1,17 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'concord/version'
+require 'circuitry/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'concord'
-  spec.version       = Concord::VERSION
+  spec.name          = 'circuitry'
+  spec.version       = Circuitry::VERSION
   spec.authors       = ['Matt Huggins']
   spec.email         = ['matt.huggins@kapost.com']
 
   spec.summary       = %q{Kapost notification pub/sub and message queue processing.}
   spec.description   = %q{Amazon SNS publishing and SQS queue processing.}
-  spec.homepage      = 'https://github.com/kapost/concord'
+  spec.homepage      = 'https://github.com/kapost/circuitry'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }

--- a/lib/circuitry.rb
+++ b/lib/circuitry.rb
@@ -1,9 +1,9 @@
-require 'concord/version'
-require 'concord/configuration'
-require 'concord/publisher'
-require 'concord/subscriber'
+require 'circuitry/version'
+require 'circuitry/configuration'
+require 'circuitry/publisher'
+require 'circuitry/subscriber'
 
-module Concord
+module Circuitry
   def self.config(&block)
     @config ||= Configuration.new
     block.call(@config) if block_given?

--- a/lib/circuitry/concerns/async.rb
+++ b/lib/circuitry/concerns/async.rb
@@ -1,4 +1,4 @@
-module Concord
+module Circuitry
   class NotSupportedError < StandardError; end
 
   module Concerns
@@ -11,7 +11,7 @@ module Concord
       end
 
       def platform_supports_async?
-        Concord.platform_supports_async?
+        Circuitry.platform_supports_async?
       end
     end
   end

--- a/lib/circuitry/configuration.rb
+++ b/lib/circuitry/configuration.rb
@@ -1,7 +1,7 @@
 require 'logger'
 require 'virtus'
 
-module Concord
+module Circuitry
   class Configuration
     include Virtus::Model
 

--- a/lib/circuitry/message.rb
+++ b/lib/circuitry/message.rb
@@ -1,7 +1,7 @@
 require 'json'
-require 'concord/topic'
+require 'circuitry/topic'
 
-module Concord
+module Circuitry
   class Message
     attr_reader :raw
 

--- a/lib/circuitry/publisher.rb
+++ b/lib/circuitry/publisher.rb
@@ -1,9 +1,9 @@
 require 'json'
-require 'concord/concerns/async'
-require 'concord/services/sns'
-require 'concord/topic_creator'
+require 'circuitry/concerns/async'
+require 'circuitry/services/sns'
+require 'circuitry/topic_creator'
 
-module Concord
+module Circuitry
   class PublishError < StandardError; end
 
   class Publisher
@@ -25,7 +25,7 @@ module Concord
       raise ArgumentError.new('object cannot be nil') if object.nil?
 
       unless can_publish?
-        logger.warn('Concord unable to publish: AWS configuration is not set.')
+        logger.warn('Circuitry unable to publish: AWS configuration is not set.')
         return
       end
 
@@ -48,11 +48,11 @@ module Concord
     private
 
     def logger
-      Concord.config.logger
+      Circuitry.config.logger
     end
 
     def can_publish?
-      Concord.config.aws_options.values.all? do |value|
+      Circuitry.config.aws_options.values.all? do |value|
         !value.nil? && !value.empty?
       end
     end

--- a/lib/circuitry/services/sns.rb
+++ b/lib/circuitry/services/sns.rb
@@ -1,10 +1,10 @@
 require 'fog/aws'
 
-module Concord
+module Circuitry
   module Services
     module SNS
       def sns
-        @sns ||= Fog::AWS::SNS.new(Concord.config.aws_options)
+        @sns ||= Fog::AWS::SNS.new(Circuitry.config.aws_options)
       end
     end
   end

--- a/lib/circuitry/services/sqs.rb
+++ b/lib/circuitry/services/sqs.rb
@@ -1,10 +1,10 @@
 require 'fog/aws'
 
-module Concord
+module Circuitry
   module Services
     module SQS
       def sqs
-        @sqs ||= Fog::AWS::SQS.new(Concord.config.aws_options)
+        @sqs ||= Fog::AWS::SQS.new(Circuitry.config.aws_options)
       end
     end
   end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -1,8 +1,8 @@
-require 'concord/concerns/async'
-require 'concord/services/sqs'
-require 'concord/message'
+require 'circuitry/concerns/async'
+require 'circuitry/services/sqs'
+require 'circuitry/message'
 
-module Concord
+module Circuitry
   class SubscribeError < StandardError; end
 
   class Subscriber
@@ -36,7 +36,7 @@ module Concord
       raise ArgumentError.new('block required') if block.nil?
 
       unless can_subscribe?
-        logger.warn('Concord unable to subscribe: AWS configuration is not set.')
+        logger.warn('Circuitry unable to subscribe: AWS configuration is not set.')
         return
       end
 
@@ -100,15 +100,15 @@ module Concord
     end
 
     def logger
-      Concord.config.logger
+      Circuitry.config.logger
     end
 
     def error_handler
-      Concord.config.error_handler
+      Circuitry.config.error_handler
     end
 
     def can_subscribe?
-      Concord.config.aws_options.values.all? do |value|
+      Circuitry.config.aws_options.values.all? do |value|
         !value.nil? && !value.empty?
       end
     end

--- a/lib/circuitry/topic.rb
+++ b/lib/circuitry/topic.rb
@@ -1,4 +1,4 @@
-module Concord
+module Circuitry
   class Topic
     attr_reader :arn
 

--- a/lib/circuitry/topic_creator.rb
+++ b/lib/circuitry/topic_creator.rb
@@ -1,7 +1,7 @@
-require 'concord/services/sns'
-require 'concord/topic'
+require 'circuitry/services/sns'
+require 'circuitry/topic'
 
-module Concord
+module Circuitry
   class TopicCreatorError < StandardError; end
 
   class TopicCreator

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
-module Concord
+module Circuitry
   VERSION = '1.0.0'
 end

--- a/spec/circuitry/concerns/async_spec.rb
+++ b/spec/circuitry/concerns/async_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 async_class = Class.new do
-  include Concord::Concerns::Async
+  include Circuitry::Concerns::Async
 end
 
 RSpec.describe async_class, type: :model do
@@ -36,19 +36,19 @@ RSpec.describe async_class, type: :model do
       end
 
       it 'raises an error' do
-        expect { subject.process_asynchronously(&block) }.to raise_error(Concord::NotSupportedError)
+        expect { subject.process_asynchronously(&block) }.to raise_error(Circuitry::NotSupportedError)
       end
     end
   end
 
   describe '#platform_supports_async?' do
     it 'returns true when delegate returns true' do
-      allow(Concord).to receive(:platform_supports_async?).and_return(true)
+      allow(Circuitry).to receive(:platform_supports_async?).and_return(true)
       expect(subject).to be_platform_supports_async
     end
 
     it 'returns false when delegate returns false' do
-      allow(Concord).to receive(:platform_supports_async?).and_return(false)
+      allow(Circuitry).to receive(:platform_supports_async?).and_return(false)
       expect(subject).to_not be_platform_supports_async
     end
   end

--- a/spec/circuitry/configuration_spec.rb
+++ b/spec/circuitry/configuration_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Concord::Configuration, type: :model do
+RSpec.describe Circuitry::Configuration, type: :model do
   describe '#aws_options' do
     before do
       subject.access_key = 'access_key'

--- a/spec/circuitry/message_spec.rb
+++ b/spec/circuitry/message_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Concord::Message, type: :model do
+RSpec.describe Circuitry::Message, type: :model do
   subject { described_class.new(raw) }
 
   let(:raw) do
@@ -21,6 +21,6 @@ RSpec.describe Concord::Message, type: :model do
   its(:id) { is_expected.to eq id }
   its(:context) { is_expected.to eq context }
   its(:body) { is_expected.to eq body }
-  its(:topic) { is_expected.to eq Concord::Topic.new(arn) }
+  its(:topic) { is_expected.to eq Circuitry::Topic.new(arn) }
   its(:receipt_handle) { is_expected.to eq handle }
 end

--- a/spec/circuitry/publisher_spec.rb
+++ b/spec/circuitry/publisher_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Concord::Publisher, type: :model do
+RSpec.describe Circuitry::Publisher, type: :model do
   subject { described_class.new(options) }
 
   let(:options) { {} }
@@ -31,7 +31,7 @@ RSpec.describe Concord::Publisher, type: :model do
       let(:mock_sns) { double('SNS', publish: true) }
 
       before do
-        allow(Concord::TopicCreator).to receive(:find_or_create).with(topic_name).and_return(topic)
+        allow(Circuitry::TopicCreator).to receive(:find_or_create).with(topic_name).and_return(topic)
         allow(subject).to receive(:sns).and_return(mock_sns)
       end
 
@@ -89,7 +89,7 @@ RSpec.describe Concord::Publisher, type: :model do
 
         it 'logs a warning' do
           subject.publish(topic_name, object)
-          expect(logger).to have_received(:warn).with('Concord unable to publish: AWS configuration is not set.')
+          expect(logger).to have_received(:warn).with('Circuitry unable to publish: AWS configuration is not set.')
         end
       end
     end

--- a/spec/circuitry/services/sns_spec.rb
+++ b/spec/circuitry/services/sns_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 sns_class = Class.new do
-  include Concord::Services::SNS
+  include Circuitry::Services::SNS
 end
 
 RSpec.describe sns_class, type: :model do
   describe '#sns' do
     before do
-      allow(Concord.config).to receive(:aws_options).and_return(aws_options)
+      allow(Circuitry.config).to receive(:aws_options).and_return(aws_options)
     end
 
     let(:aws_options) { { aws_access_key_id: 'foo', aws_secret_access_key: 'bar' } }

--- a/spec/circuitry/services/sqs_spec.rb
+++ b/spec/circuitry/services/sqs_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 sqs_class = Class.new do
-  include Concord::Services::SQS
+  include Circuitry::Services::SQS
 end
 
 RSpec.describe sqs_class, type: :model do
   describe '#sqs' do
     before do
-      allow(Concord.config).to receive(:aws_options).and_return(aws_options)
+      allow(Circuitry.config).to receive(:aws_options).and_return(aws_options)
     end
 
     let(:aws_options) { { aws_access_key_id: 'foo', aws_secret_access_key: 'bar' } }

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Concord::Subscriber, type: :model do
+RSpec.describe Circuitry::Subscriber, type: :model do
   subject { described_class.new(queue, options) }
 
   let(:queue) { 'https://sqs.amazon.com/account/queue' }
@@ -47,6 +47,13 @@ RSpec.describe Concord::Subscriber, type: :model do
         it 'subscribes to SQS' do
           subject.subscribe(&block)
           expect(mock_sqs).to have_received(:receive_message).with(queue, any_args)
+        end
+
+        describe 'when a connection error is raised' do
+          it 'raises wraps the error' do
+            allow(subject).to receive(:receive_messages).and_raise(described_class::CONNECTION_ERRORS.first, 'Forbidden')
+            expect { subject.subscribe(&block) }.to raise_error(Circuitry::SubscribeError)
+          end
         end
 
         shared_examples_for 'a valid subscribe request' do
@@ -158,7 +165,7 @@ RSpec.describe Concord::Subscriber, type: :model do
 
         it 'logs a warning' do
           subject.subscribe(&block)
-          expect(logger).to have_received(:warn).with('Concord unable to subscribe: AWS configuration is not set.')
+          expect(logger).to have_received(:warn).with('Circuitry unable to subscribe: AWS configuration is not set.')
         end
       end
     end

--- a/spec/circuitry/topic_creator_spec.rb
+++ b/spec/circuitry/topic_creator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Concord::TopicCreator, type: :model do
+RSpec.describe Circuitry::TopicCreator, type: :model do
   describe '.find_or_create' do
     subject { described_class }
 
@@ -39,7 +39,7 @@ RSpec.describe Concord::TopicCreator, type: :model do
       let(:arn) { 'arn:aws:sns:us-east-1:123456789012:some-topic-name' }
 
       it 'returns the topic' do
-        expect(subject.topic).to be_a Concord::Topic
+        expect(subject.topic).to be_a Circuitry::Topic
       end
 
       it 'sets the topic ARN' do
@@ -51,7 +51,7 @@ RSpec.describe Concord::TopicCreator, type: :model do
       let(:body) { {} }
 
       it 'raises an error' do
-        expect { subject.topic }.to raise_error(Concord::TopicCreatorError)
+        expect { subject.topic }.to raise_error(Circuitry::TopicCreatorError)
       end
     end
   end

--- a/spec/circuitry/topic_spec.rb
+++ b/spec/circuitry/topic_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Concord::Topic, type: :model do
+RSpec.describe Circuitry::Topic, type: :model do
   subject { described_class.new(arn) }
 
   let(:arn) { 'arn:aws:sqs:us-east-1:123456789012:some-topic-name' }

--- a/spec/circuitry_spec.rb
+++ b/spec/circuitry_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-RSpec.describe Concord, type: :model do
+RSpec.describe Circuitry, type: :model do
   subject { described_class }
 
   describe '.config' do
     it 'returns a configuration object' do
-      expect(subject.config).to be_a Concord::Configuration
+      expect(subject.config).to be_a Circuitry::Configuration
     end
 
     it 'always returns the same object' do
@@ -26,7 +26,7 @@ RSpec.describe Concord, type: :model do
       object = double('Object')
       options = { foo: 'bar' }
 
-      allow(Concord::Publisher).to receive(:new).with(options).and_return(publisher)
+      allow(Circuitry::Publisher).to receive(:new).with(options).and_return(publisher)
       subject.publish(topic, object, options)
       expect(publisher).to have_received(:publish).with(topic, object)
     end
@@ -39,7 +39,7 @@ RSpec.describe Concord, type: :model do
       block = -> { }
       options = { foo: 'bar' }
 
-      allow(Concord::Subscriber).to receive(:new).with(queue, options).and_return(subscriber)
+      allow(Circuitry::Subscriber).to receive(:new).with(queue, options).and_return(subscriber)
       subject.subscribe(queue, options, &block)
       expect(subscriber).to have_received(:subscribe).with(no_args, &block)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'concord'
+require 'circuitry'
 require 'rspec/its'
 require 'pry'
 require 'pry-nav'


### PR DESCRIPTION
@kapost/core These changes rename the gem from Concord to Circuitry.  All tests are passing.
