### PR TITLE
Timeout if publishing or subscribing exceeds a threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,12 @@ The `publish` method also accepts options that impact instantiation of the
   the `publish_async_strategy` value from the gem configuration.  Please refer to
   the [Asynchronous Support](#asynchronous-support) section for more details
   regarding this option.  *(default: `false`)*
+* `:timeout` - The maximum amount of time in seconds that publishing a message
+  will be attempted before giving up.  *(default: 15)*
 
 ```ruby
 obj = { foo: 'foo', bar: 'bar' }
-Circuitry.publish('my-topic-name', obj, async: true)
+Circuitry.publish('my-topic-name', obj, async: true, timeout: 20)
 ```
 
 Alternatively, if your options hash will remain unchanged, you can build a single
@@ -127,6 +129,8 @@ The `subscribe` method also accepts options that impact instantiation of the
   that queued messages *might not be processed in the order they're received*.
   Please refer to the [Asynchronous Support](#asynchronous-support) section for
   more details regarding this option.  *(default: `false`)*
+* `:timeout` - The maximum amount of time in seconds that processing a message
+  will be attempted before giving up.  *(default: 15)*
 * `:wait_time` - The number of seconds to wait for messages while connected to
   SQS.  Anything above 0 results in long-polling, while 0 results in
   short-polling.  *(default: 10)*
@@ -134,7 +138,7 @@ The `subscribe` method also accepts options that impact instantiation of the
   *(default: 10)*
 
 ```ruby
-Circuitry.subscribe('https://...', async: true, wait_time: 60, batch_size: 20) do |message, topic_name|
+Circuitry.subscribe('https://...', async: true, timeout: 20, wait_time: 60, batch_size: 20) do |message, topic_name|
   # ...
 end
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ The `publish` method also accepts options that impact instantiation of the
   the [Asynchronous Support](#asynchronous-support) section for more details
   regarding this option.  *(default: `false`)*
 * `:timeout` - The maximum amount of time in seconds that publishing a message
-  will be attempted before giving up.  *(default: 15)*
+  will be attempted before giving up.  If the timeout is exceeded, an exception
+  will raised to be handled by your application or `error_handler`. *(default:
+  15)*
 
 ```ruby
 obj = { foo: 'foo', bar: 'bar' }
@@ -130,7 +132,9 @@ The `subscribe` method also accepts options that impact instantiation of the
   Please refer to the [Asynchronous Support](#asynchronous-support) section for
   more details regarding this option.  *(default: `false`)*
 * `:timeout` - The maximum amount of time in seconds that processing a message
-  will be attempted before giving up.  *(default: 15)*
+  will be attempted before giving up.  If the timeout is exceeded, an exception
+  will raised to be handled by your application or `error_handler`.  *(default:
+  15)*
 * `:wait_time` - The number of seconds to wait for messages while connected to
   SQS.  Anything above 0 results in long-polling, while 0 results in
   short-polling.  *(default: 10)*


### PR DESCRIPTION
@kapost/core This adds support for timing out message processing on both the publisher and subscriber.  Resolves #11.  /cc @pk-nb 