### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
Bump version to include the lock strategy and timeout changes.