### PR TITLE
Feature/unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ following methods:
   processed more than once.
 * `lock!`: Accepts the `key` and `ttl` as parameters.  Must lock the key for
   `ttl` seconds regardless of whether or not the key was previously locked.
+* `unlock!`: Accepts the `key` as a parameter.  Must unlock (delete) the key if
+  it was previously locked.
 
 For example, a database-backed solution might look something like the following:
 
@@ -359,6 +361,10 @@ class DatabaseLockStrategy
 
   def lock!(key, ttl)
     connection.exec("UPSERT INTO locks (key, expires_at) VALUES ('#{key}', '#{Time.now + ttl}')")
+  end
+
+  def unlock!(key)
+    connection.exec("DELETE FROM locks WHERE key = '#{key}'")
   end
 
   private

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ The circuitry gem handles this by caching SQS message IDs: first via a "soft
 lock" that denotes the message is about to be processed, then via a "hard lock"
 that denotes the message has finished processing.
 
-The soft lock has a default TTL of 15 minutes (a seemingly sane amount of time
+The soft lock has a default TTL of 5 minutes (a seemingly sane amount of time
 during which processing most queue messages should certainly be able to
 complete), while the hard lock has a default TTL of 24 hours (based upon
 [a suggestion by an AWS employee](https://forums.aws.amazon.com/thread.jspa?threadID=140782#507605)).

--- a/lib/circuitry/locks/base.rb
+++ b/lib/circuitry/locks/base.rb
@@ -19,6 +19,10 @@ module Circuitry
         lock!(lock_key(id), hard_ttl)
       end
 
+      def unlock(id)
+        unlock!(lock_key(id))
+      end
+
       protected
 
       def lock(key, ttl)
@@ -26,6 +30,10 @@ module Circuitry
       end
 
       def lock!(key, ttl)
+        raise NotImplementedError
+      end
+
+      def unlock!(key)
         raise NotImplementedError
       end
 

--- a/lib/circuitry/locks/base.rb
+++ b/lib/circuitry/locks/base.rb
@@ -1,7 +1,7 @@
 module Circuitry
   module Locks
     module Base
-      DEFAULT_SOFT_TTL = (15 * 60).freeze       # 15 minutes
+      DEFAULT_SOFT_TTL = (5 * 60).freeze        # 5 minutes
       DEFAULT_HARD_TTL = (24 * 60 * 60).freeze  # 24 hours
 
       attr_reader :soft_ttl, :hard_ttl

--- a/lib/circuitry/locks/memcache.rb
+++ b/lib/circuitry/locks/memcache.rb
@@ -22,6 +22,10 @@ module Circuitry
         client.set(key, (Time.now + ttl).to_i, ttl)
       end
 
+      def unlock!(key)
+        client.delete(key)
+      end
+
       private
 
       attr_accessor :client

--- a/lib/circuitry/locks/memory.rb
+++ b/lib/circuitry/locks/memory.rb
@@ -36,6 +36,12 @@ module Circuitry
         end
       end
 
+      def unlock!(key)
+        store do |store|
+          store.delete(key)
+        end
+      end
+
       private
 
       def store(&block)

--- a/lib/circuitry/locks/noop.rb
+++ b/lib/circuitry/locks/noop.rb
@@ -12,6 +12,10 @@ module Circuitry
       def lock!(key, ttl)
         # do nothing
       end
+
+      def unlock!(key)
+        # do nothing
+      end
     end
   end
 end

--- a/lib/circuitry/locks/redis.rb
+++ b/lib/circuitry/locks/redis.rb
@@ -22,6 +22,10 @@ module Circuitry
         client.set(key, (Time.now + ttl).to_i, ex: ttl)
       end
 
+      def unlock!(key)
+        client.del(key)
+      end
+
       private
 
       attr_accessor :client

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -116,6 +116,7 @@ module Circuitry
             block.call(message.body, message.topic.name)
           end
         rescue => e
+          lock.unlock(message.id)
           logger.error("Error handling message #{message.id}: #{e}")
           raise e
         end

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/circuitry/locks/base_spec.rb
+++ b/spec/circuitry/locks/base_spec.rb
@@ -8,6 +8,9 @@ lock_class = Class.new do
 
   def lock!(key, ttl)
   end
+
+  def unlock!(key)
+  end
 end
 
 incomplete_lock_class = Class.new do
@@ -59,6 +62,29 @@ RSpec.describe Circuitry::Locks::Base, type: :model do
 
       it 'raises an error' do
         expect { subject.hard_lock(id) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe '#unlock' do
+    let(:id) { SecureRandom.hex(100) }
+
+    describe 'when the class has defined #unlock!' do
+      it 'delegates to the #unlock method' do
+        expect(subject).to receive(:unlock!).with("circuitry:lock:#{id}")
+        subject.unlock(id)
+      end
+
+      it 'does not raise an error' do
+        expect { subject.unlock(id) }.to_not raise_error
+      end
+    end
+
+    describe 'when the class has not defined #unlock!' do
+      subject { incomplete_lock_class.new }
+
+      it 'raises an error' do
+        expect { subject.unlock(id) }.to raise_error(NotImplementedError)
       end
     end
   end

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -199,6 +199,11 @@ RSpec.describe Circuitry::Subscriber, type: :model do
               expect(mock_sqs).to_not have_received(:delete_message).with(queue, 'delete-one')
             end
 
+            it 'unlocks failing messages' do
+              expect(subject.lock).to receive(:unlock).with('one')
+              subject.subscribe(&block)
+            end
+
             describe 'when error logger is configured' do
               let(:error_handler) { ->(_) { } }
 

--- a/spec/support/examples/lock_examples.rb
+++ b/spec/support/examples/lock_examples.rb
@@ -73,4 +73,17 @@ RSpec.shared_examples_for 'a lock' do
       it_behaves_like 'an overwriting lock'
     end
   end
+
+  describe '#lock' do
+    let(:id) { SecureRandom.hex(100) }
+
+    before do
+      subject.hard_lock(id)
+    end
+
+    it 'deletes the lock' do
+      subject.unlock(id)
+      expect(subject.soft_lock(id)).to be true
+    end
+  end
 end


### PR DESCRIPTION
@kapost/core This adds unlock functionality to the locking strategies.

Previously, the gem was soft locking for a short duration (15 min.) before processing, then hard locking for a long duration (24 hr.) if processing succeeded.  If processing does not succeed (e.g.: your custom handler code raises an error), then the soft lock persists while SQS continues to send the message to your subscriber.  If your SQS queue implements a "Dead Letter Queue", then each time SQS sends the message, it increments the count towards the "Maximum Receive" value.  If this number is relatively low, it's possible for your app to receive the message 10 times (for example) while only actually trying to process it against the user's code once.

Additionally, I've reduced the default soft lock duration from 15 minutes to 5 minutes.  This value is already configurable if the new value is too short, but I imagine 5 minutes should be more than enough time for any processing to occur against a received message for most systems.