### PR TITLE
Ignore temporary service errors

### DIFF
--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end


### PR DESCRIPTION
@kapost/core We're currently raising a number of service errors that are expected to happen intermittently (internal server error, service unavailable, & timeouts).  These errors are temporary and expected to happen on occasion, so we should do nothing beyond returning the same way we would when no messages are available.

* Note about [internal error & service unavailable error](https://aws.amazon.com/articles/Amazon-SQS/1343#13)
* Note about [service timeouts](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html)

I've also bumped the version to 1.2.2.