### PR TITLE
Handle excon error for "connection reset by peer"

### DIFF
--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -27,6 +27,7 @@ module Circuitry
     TEMPORARY_ERRORS = [
         Excon::Errors::InternalServerError,
         Excon::Errors::ServiceUnavailable,
+        Excon::Errors::SocketError,
         Excon::Errors::Timeout,
     ].freeze
 

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '1.2.2'
+  VERSION = '1.2.3'
 end


### PR DESCRIPTION
@kapost/core @iamnader Sometimes SQS resets the connection while we're waiting for any pending messages.  We should handle this gracefully rather than terminating the subscriber loop.