### PR TITLE
Add thread and fork exit hooks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,9 @@
+---
+engines:
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+exclude_paths:
+- spec/**/*

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Circuitry.config do |c|
   c.lock_strategy = Circuitry::Locks::Redis.new(url: 'redis://localhost:6379')
   c.publish_async_strategy = :batch
   c.subscribe_async_strategy = :thread
+  c.on_thread_exit = proc { Mongoid.disconnect_sessions }
+  c.on_fork_exit = proc { Mongoid.disconnect_sessions }
 end
 ```
 
@@ -73,6 +75,14 @@ Available configuration options include:
     queue.
   * `:thread`: Creates a new thread that immediately sends begins querying the
     queue.
+* `on_thread_exit`: An object that responds to `call`.  This is useful for
+  managing shared resources such as database connections that require closing.
+  It is only called when implementing the `:thread` async strategy.  *(optional,
+  default: `nil`)*
+* `on_fork_exit`: An object that responds to `call`.  This is useful for
+  managing shared resources such as database connections that require closing,
+  It is only called when implementing the `:fork` async strategy.  *(optional,
+  default: `nil`)*
 
 ### Publishing
 

--- a/lib/circuitry/configuration.rb
+++ b/lib/circuitry/configuration.rb
@@ -13,6 +13,8 @@ module Circuitry
     attribute :lock_strategy, Object, default: ->(page, attribute) { Circuitry::Locks::Memory.new }
     attribute :publish_async_strategy, Symbol, default: ->(page, attribute) { :fork }
     attribute :subscribe_async_strategy, Symbol, default: ->(page, attribute) { :fork }
+    attribute :on_thread_exit
+    attribute :on_fork_exit
 
     def publish_async_strategy=(value)
       validate(value, Publisher.async_strategies)

--- a/lib/circuitry/processors/forker.rb
+++ b/lib/circuitry/processors/forker.rb
@@ -7,7 +7,11 @@ module Circuitry
         include Processor
 
         def process(&block)
-          pid = fork { safely_process(&block) }
+          pid = fork do
+            safely_process(&block)
+            Circuitry.config.on_fork_exit.call if Circuitry.config.on_fork_exit
+          end
+
           Process.detach(pid)
         end
 

--- a/lib/circuitry/processors/threader.rb
+++ b/lib/circuitry/processors/threader.rb
@@ -8,7 +8,11 @@ module Circuitry
 
         def process(&block)
           raise ArgumentError, 'no block given' unless block_given?
-          pool << Thread.new { safely_process(&block) }
+
+          pool << Thread.new do
+            safely_process(&block)
+            Circuitry.config.on_thread_exit.call if Circuitry.config.on_thread_exit
+          end
         end
 
         def flush

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '1.2.3'
+  VERSION = '1.3.0'
 end

--- a/spec/circuitry/processors/forker_spec.rb
+++ b/spec/circuitry/processors/forker_spec.rb
@@ -30,4 +30,21 @@ RSpec.describe Circuitry::Processors::Forker, type: :model do
       expect { subject.flush }.to_not raise_error
     end
   end
+
+  describe 'when on_fork_exit is defined' do
+    let(:block) { ->{ } }
+    let(:on_fork_exit) { double('Proc', call: true) }
+
+    before do
+      allow(subject).to receive(:fork) { |&block| block.call }
+      allow(Process).to receive(:detach)
+      allow(Circuitry.config).to receive(:on_fork_exit).and_return(on_fork_exit)
+    end
+
+    it 'calls the proc' do
+      subject.process(&block)
+      subject.flush
+      expect(on_fork_exit).to have_received(:call)
+    end
+  end
 end

--- a/spec/circuitry/processors/threader_spec.rb
+++ b/spec/circuitry/processors/threader_spec.rb
@@ -43,4 +43,19 @@ RSpec.describe Circuitry::Processors::Threader, type: :model do
       expect(pool).to be_empty
     end
   end
+
+  describe 'when on_thread_exit is defined' do
+    let(:block) { ->{ } }
+    let(:on_thread_exit) { double('Proc', call: true) }
+
+    before do
+      allow(Circuitry.config).to receive(:on_thread_exit).and_return(on_thread_exit)
+    end
+
+    it 'calls the proc' do
+      subject.process(&block)
+      subject.flush
+      expect(on_thread_exit).to have_received(:call)
+    end
+  end
 end


### PR DESCRIPTION
@kapost/core This will allow us to hook into circuitry threads and forks to close database connections properly.  The fork option might not be as useful since, for example, unicorn offers `before_fork` and `after_fork` blocks.  I thought it would still be useful to include them for the sake of completeness though.