### PR TITLE
Enable redis connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,13 +297,18 @@ a new `Redis` object.
 Circuitry::Locks::Redis.new(url: 'redis://localhost:6379')
 ```
 
-The second way is to pass in a `:client` option that specifies the redis client
-itself.  This is useful for more advanced usage such as sharing an existing redis
-connection, utilizing [Redis::Namespace](https://github.com/resque/redis-namespace),
-or utilizing [hiredis](https://github.com/redis/hiredis-rb).
+The second way is to pass in a `:client` option that specifies either the redis
+client itself or a [ConnectionPool](https://github.com/mperham/connection_pool)
+of redis clients.  This is useful for more advanced usage such as sharing an
+existing redis connection, connection pooling, utilizing
+[Redis::Namespace](https://github.com/resque/redis-namespace), or utilizing
+[hiredis](https://github.com/redis/hiredis-rb).
 
 ```ruby
 client = Redis.new(url: 'redis://localhost:6379')
+Circuitry::Locks::Redis.new(client: client)
+
+client = ConnectionPool.new(size: 5) { Redis.new }
 Circuitry::Locks::Redis.new(client: client)
 ```
 

--- a/lib/circuitry/locks/redis.rb
+++ b/lib/circuitry/locks/redis.rb
@@ -15,20 +15,38 @@ module Circuitry
       protected
 
       def lock(key, ttl)
-        client.set(key, (Time.now + ttl).to_i, ex: ttl, nx: true)
+        with_pool do |client|
+          client.set(key, (Time.now + ttl).to_i, ex: ttl, nx: true)
+        end
       end
 
       def lock!(key, ttl)
-        client.set(key, (Time.now + ttl).to_i, ex: ttl)
+        with_pool do |client|
+          client.set(key, (Time.now + ttl).to_i, ex: ttl)
+        end
       end
 
       def unlock!(key)
-        client.del(key)
+        with_pool do |client|
+          client.del(key)
+        end
       end
 
       private
 
       attr_accessor :client
+
+      def with_pool(&block)
+        if pool?
+          client.with(&block)
+        else
+          block.call(client)
+        end
+      end
+
+      def pool?
+        defined?(ConnectionPool) && client.is_a?(ConnectionPool)
+      end
     end
   end
 end


### PR DESCRIPTION
@kapost/core This permits the redis lock strategy to utilize the [ConnectionPool gem](https://github.com/mperham/connection_pool) instead of a single redis connection.  Thoughts?