### PR TITLE
Retry deletes after successful processing

### DIFF
--- a/circuitry.gemspec
+++ b/circuitry.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'fog-aws', '~> 0.4'
+  spec.add_dependency 'retries', '~> 0.0.5'
   spec.add_dependency 'virtus', '~> 1.0'
 
   spec.add_development_dependency 'pry-byebug'

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -1,3 +1,4 @@
+require 'retries'
 require 'timeout'
 require 'circuitry/concerns/async'
 require 'circuitry/services/sqs'
@@ -144,7 +145,14 @@ module Circuitry
 
     def delete_message(message)
       logger.info("Removing message #{message.id} from queue")
-      sqs.delete_message(queue, message.receipt_handle)
+
+      handler = ->(exception, attempt_number, total_delay) do
+        logger.info("Temporary issue deleting message #{message.id} from SQS: #{exception.message} (attempt ##{attempt_number})")
+      end
+
+      with_retries(max_tries: 3, base_sleep_seconds: 0, max_sleep_seconds: 0, handler: handler, rescue: TEMPORARY_ERRORS) do
+        sqs.delete_message(queue, message.receipt_handle)
+      end
     end
 
     def logger

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -146,7 +146,7 @@ module Circuitry
     def delete_message(message)
       logger.info("Removing message #{message.id} from queue")
 
-      handler = ->(exception, attempt_number, total_delay) do
+      handler = ->(exception, attempt_number, _total_delay) do
         logger.info("Temporary issue deleting message #{message.id} from SQS: #{exception.message} (attempt ##{attempt_number})")
       end
 


### PR DESCRIPTION
@kapost/core I'm seeing some stack traces in Honeybadger that relate to temporary connection issues when deleting a message after handling is completed.  This is less than ideal since it means a message could be processed multiple times.

This change will allow deletes to be retried when a temporary issue is encountered.  Interested in feedback.