### PR TITLE
Add tests for redis connection pool

### DIFF
--- a/circuitry.gemspec
+++ b/circuitry.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mock_redis'
   spec.add_development_dependency 'dalli'
   spec.add_development_dependency 'memcache_mock'
+  spec.add_development_dependency 'connection_pool'
 end

--- a/spec/circuitry/locks/redis_spec.rb
+++ b/spec/circuitry/locks/redis_spec.rb
@@ -8,10 +8,18 @@ RSpec.describe Circuitry::Locks::Redis, type: :model do
   let(:client) { MockRedis.new }
 
   before do
-    client.flushdb
+    client.respond_to?(:flushdb) ? client.flushdb : client.with(&:flushdb)
   end
 
-  it_behaves_like 'a lock'
+  describe 'with redis connection' do
+    it_behaves_like 'a lock'
+  end
+
+  describe 'with redis connection pool' do
+    let(:client) { ConnectionPool.new(size: 1) { MockRedis.new } }
+
+    it_behaves_like 'a lock'
+  end
 
   describe '.new' do
     subject { described_class }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'redis'
 require 'mock_redis'
 require 'dalli'
 require 'memcache_mock'
+require 'connection_pool'
 require 'pry-byebug'
 require 'securerandom'
 


### PR DESCRIPTION
@kapost/core This adds some tests I neglected to include when implementing redis connection pooling.