### PR TITLE
Replace fog-aws with aws-sdk

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,9 +1,0 @@
----
-engines:
-  rubocop:
-    enabled: true
-ratings:
-  paths:
-  - "**.rb"
-exclude_paths:
-- spec/**/*

--- a/circuitry.gemspec
+++ b/circuitry.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fog-aws', '~> 0.4'
+  spec.add_dependency 'aws-sdk', '~> 2'
   spec.add_dependency 'retries', '~> 0.0.5'
   spec.add_dependency 'virtus', '~> 1.0'
 

--- a/lib/circuitry/configuration.rb
+++ b/lib/circuitry/configuration.rb
@@ -28,9 +28,9 @@ module Circuitry
 
     def aws_options
       {
-          aws_access_key_id:     access_key,
-          aws_secret_access_key: secret_key,
-          region:                region,
+          access_key_id:     access_key,
+          secret_access_key: secret_key,
+          region:            region,
       }
     end
 

--- a/lib/circuitry/message.rb
+++ b/lib/circuitry/message.rb
@@ -3,14 +3,14 @@ require 'circuitry/topic'
 
 module Circuitry
   class Message
-    attr_reader :raw
+    attr_reader :sqs_message
 
-    def initialize(raw)
-      @raw = raw
+    def initialize(sqs_message)
+      @sqs_message = sqs_message
     end
 
     def context
-      @context ||= JSON.parse(raw['Body'])
+      @context ||= JSON.parse(sqs_message.body)
     end
 
     def body
@@ -22,11 +22,11 @@ module Circuitry
     end
 
     def id
-      raw['MessageId']
+      sqs_message.message_id
     end
 
     def receipt_handle
-      raw['ReceiptHandle']
+      sqs_message.receipt_handle
     end
   end
 end

--- a/lib/circuitry/publisher.rb
+++ b/lib/circuitry/publisher.rb
@@ -28,16 +28,12 @@ module Circuitry
     def publish(topic_name, object)
       raise ArgumentError.new('topic_name cannot be nil') if topic_name.nil?
       raise ArgumentError.new('object cannot be nil') if object.nil?
-
-      unless can_publish?
-        logger.warn('Circuitry unable to publish: AWS configuration is not set.')
-        return
-      end
+      raise PublishError.new('AWS configuration is not set') unless can_publish?
 
       process = -> do
         Timeout.timeout(timeout) do
           topic = TopicCreator.find_or_create(topic_name)
-          sns.publish(topic.arn, object.to_json)
+          sns.publish(topic_arn: topic.arn, message: object.to_json)
         end
       end
 

--- a/lib/circuitry/services/sns.rb
+++ b/lib/circuitry/services/sns.rb
@@ -1,10 +1,10 @@
-require 'fog/aws'
+require 'aws-sdk'
 
 module Circuitry
   module Services
     module SNS
       def sns
-        @sns ||= Fog::AWS::SNS.new(Circuitry.config.aws_options)
+        @sns ||= Aws::SNS::Client.new(Circuitry.config.aws_options)
       end
     end
   end

--- a/lib/circuitry/services/sqs.rb
+++ b/lib/circuitry/services/sqs.rb
@@ -1,10 +1,10 @@
-require 'fog/aws'
+require 'aws-sdk'
 
 module Circuitry
   module Services
     module SQS
       def sqs
-        @sqs ||= Fog::AWS::SQS.new(Circuitry.config.aws_options)
+        @sqs ||= Aws::SQS::Client.new(Circuitry.config.aws_options)
       end
     end
   end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -22,6 +22,7 @@ module Circuitry
     }.freeze
 
     CONNECTION_ERRORS = [
+        Aws::SQS::Errors::ServiceError,
     ].freeze
 
     def initialize(queue, options = {})

--- a/lib/circuitry/topic_creator.rb
+++ b/lib/circuitry/topic_creator.rb
@@ -2,8 +2,6 @@ require 'circuitry/services/sns'
 require 'circuitry/topic'
 
 module Circuitry
-  class TopicCreatorError < StandardError; end
-
   class TopicCreator
     include Services::SNS
 
@@ -20,9 +18,8 @@ module Circuitry
     def topic
       return @topic if defined?(@topic)
 
-      response = sns.create_topic(topic_name)
-      arn = response.body.fetch('TopicArn') { raise TopicCreatorError.new('No TopicArn returned from SNS') }
-      @topic = Topic.new(arn)
+      response = sns.create_topic(name: topic_name)
+      @topic = Topic.new(response.topic_arn)
     end
   end
 end

--- a/spec/circuitry/configuration_spec.rb
+++ b/spec/circuitry/configuration_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Circuitry::Configuration, type: :model do
     end
 
     it 'returns a hash of AWS connection options' do
-      expect(subject.aws_options).to eq(aws_access_key_id: 'access_key', aws_secret_access_key: 'secret_key', region: 'region')
+      expect(subject.aws_options).to eq(access_key_id: 'access_key', secret_access_key: 'secret_key', region: 'region')
     end
   end
 end

--- a/spec/circuitry/message_spec.rb
+++ b/spec/circuitry/message_spec.rb
@@ -1,15 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe Circuitry::Message, type: :model do
-  subject { described_class.new(raw) }
+  subject { described_class.new(sqs_message) }
 
-  let(:raw) do
-    {
-        'MessageId' => id,
-        'ReceiptHandle' => handle,
-        'Body' => context.to_json,
-    }
-  end
+  let(:sqs_message) { double(message_id: id, receipt_handle: handle, body: context.to_json) }
 
   let(:id) { '123' }
   let(:handle) { '456' }
@@ -17,7 +11,7 @@ RSpec.describe Circuitry::Message, type: :model do
   let(:arn) { 'arn:aws:sns:us-east-1:123456789012:test-event-task-changed' }
   let(:context) { { 'Message' => body.to_json, 'TopicArn' => arn } }
 
-  its(:raw) { is_expected.to eq raw }
+  its(:sqs_message) { is_expected.to eq sqs_message }
   its(:id) { is_expected.to eq id }
   its(:context) { is_expected.to eq context }
   its(:body) { is_expected.to eq body }

--- a/spec/circuitry/publisher_spec.rb
+++ b/spec/circuitry/publisher_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe Circuitry::Publisher, type: :model do
 
       describe 'when AWS credentials are set' do
         before do
-          allow(Circuitry.config).to receive(:aws_options).and_return(aws_access_key_id: 'key', aws_secret_access_key: 'secret', region: 'region')
+          allow(Circuitry.config).to receive(:aws_options).and_return(access_key_id: 'key', secret_access_key: 'secret', region: 'region')
         end
 
         shared_examples_for 'a valid publish request' do
           it 'publishes to SNS' do
             subject.publish(topic_name, object)
-            expect(mock_sns).to have_received(:publish).with(topic.arn, object.to_json)
+            expect(mock_sns).to have_received(:publish).with(topic_arn: topic.arn, message: object.to_json)
           end
         end
 
@@ -78,20 +78,16 @@ RSpec.describe Circuitry::Publisher, type: :model do
 
       describe 'when AWS credentials are not set' do
         before do
-          allow(Circuitry.config).to receive(:aws_options).and_return(aws_access_key_id: '', aws_secret_access_key: '', region: 'region')
-          allow(Circuitry.config).to receive(:logger).and_return(logger)
+          allow(Circuitry.config).to receive(:aws_options).and_return(access_key_id: '', secret_access_key: '', region: 'region')
         end
 
-        let(:logger) { double('Logger', warn: true) }
-
         it 'does not publish to SNS' do
-          subject.publish(topic_name, object)
-          expect(mock_sns).to_not have_received(:publish).with(topic.arn, object.to_json)
+          subject.publish(topic_name, object) rescue nil
+          expect(mock_sns).to_not have_received(:publish).with(topic_arn: topic.arn, message: object.to_json)
         end
 
         it 'logs a warning' do
-          subject.publish(topic_name, object)
-          expect(logger).to have_received(:warn).with('Circuitry unable to publish: AWS configuration is not set.')
+          expect { subject.publish(topic_name, object) }.to raise_error(Circuitry::PublishError)
         end
       end
     end

--- a/spec/circuitry/services/sns_spec.rb
+++ b/spec/circuitry/services/sns_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe sns_class, type: :model do
       allow(Circuitry.config).to receive(:aws_options).and_return(aws_options)
     end
 
-    let(:aws_options) { { aws_access_key_id: 'foo', aws_secret_access_key: 'bar' } }
+    let(:aws_options) { { access_key_id: 'foo', secret_access_key: 'bar', region: 'us-east-1' } }
 
-    it 'returns a fog SNS instance' do
-      expect(subject.sns).to be_a Fog::AWS::SNS::Real
+    it 'returns an SNS instance' do
+      expect(subject.sns).to be_an Aws::SNS::Client
     end
 
     it 'uses the AWS configuration options' do
-      expect(Fog::AWS::SNS).to receive(:new).with(aws_options)
+      expect(Aws::SNS::Client).to receive(:new).with(aws_options)
       subject.sns
     end
   end

--- a/spec/circuitry/services/sqs_spec.rb
+++ b/spec/circuitry/services/sqs_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe sqs_class, type: :model do
       allow(Circuitry.config).to receive(:aws_options).and_return(aws_options)
     end
 
-    let(:aws_options) { { aws_access_key_id: 'foo', aws_secret_access_key: 'bar' } }
+    let(:aws_options) { { access_key_id: 'foo', secret_access_key: 'bar', region: 'us-east-1' } }
 
-    it 'returns a fog SQS instance' do
-      expect(subject.sqs).to be_a Fog::AWS::SQS::Real
+    it 'returns an SQS instance' do
+      expect(subject.sqs).to be_an Aws::SQS::Client
     end
 
     it 'uses the AWS configuration options' do
-      expect(Fog::AWS::SQS).to receive(:new).with(aws_options)
+      expect(Aws::SQS::Client).to receive(:new).with(aws_options)
       subject.sqs
     end
   end

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -107,20 +107,22 @@ RSpec.describe Circuitry::Subscriber, type: :model do
           expect(mock_sqs).to have_received(:receive_message).with(hash_including(queue_url: queue))
         end
 
-        # describe 'when a connection error is raised' do
-        #   before do
-        #     allow(subject).to receive(:receive_messages).and_raise(described_class::CONNECTION_ERRORS.first, 'Forbidden')
-        #   end
-        #
-        #   it 'raises a wrapped error' do
-        #     expect { subject.subscribe(&block) }.to raise_error(Circuitry::SubscribeError)
-        #   end
-        #
-        #   it 'logs an error' do
-        #     subject.subscribe(&block) rescue nil
-        #     expect(logger).to have_received(:error)
-        #   end
-        # end
+        describe 'when a connection error is raised' do
+          before do
+            allow(subject).to receive(:receive_messages).and_raise(error)
+          end
+
+          let(:error) { described_class::CONNECTION_ERRORS.first.new(double('Seahorse::Client::RequestContext'), 'Queue does not exist') }
+
+          it 'raises a wrapped error' do
+            expect { subject.subscribe(&block) }.to raise_error(Circuitry::SubscribeError)
+          end
+
+          it 'logs an error' do
+            subject.subscribe(&block) rescue nil
+            expect(logger).to have_received(:error)
+          end
+        end
 
         shared_examples_for 'a valid subscribe request' do
           let(:messages) do

--- a/spec/circuitry/topic_creator_spec.rb
+++ b/spec/circuitry/topic_creator_spec.rb
@@ -27,32 +27,20 @@ RSpec.describe Circuitry::TopicCreator, type: :model do
 
     let(:topic_name) { 'topic' }
     let(:mock_sns) { double('SNS') }
-    let(:response) { double('Response', body: body) }
+    let(:response) { double('Aws::SNS::Types::CreateTopicResponse', topic_arn: arn) }
+    let(:arn) { 'arn:aws:sns:us-east-1:123456789012:some-topic-name' }
 
     before do
       allow(subject).to receive(:sns).and_return(mock_sns)
-      allow(mock_sns).to receive(:create_topic).with(topic_name).and_return(response)
+      allow(mock_sns).to receive(:create_topic).with(name: topic_name).and_return(response)
     end
 
-    describe 'when response includes a topic ARN' do
-      let(:body) { { 'TopicArn' => arn } }
-      let(:arn) { 'arn:aws:sns:us-east-1:123456789012:some-topic-name' }
-
-      it 'returns the topic' do
-        expect(subject.topic).to be_a Circuitry::Topic
-      end
-
-      it 'sets the topic ARN' do
-        expect(subject.topic.arn).to eq arn
-      end
+    it 'returns the topic' do
+      expect(subject.topic).to be_a Circuitry::Topic
     end
 
-    describe 'when response does not include a topic ARN' do
-      let(:body) { {} }
-
-      it 'raises an error' do
-        expect { subject.topic }.to raise_error(Circuitry::TopicCreatorError)
-      end
+    it 'sets the topic ARN' do
+      expect(subject.topic.arn).to eq arn
     end
   end
 end


### PR DESCRIPTION
@kapost/core @alexmcpherson @paul This replaces the fog-aws gem with aws-sdk.  The reasoning behind this is that long polling was introduced in SQS API version 2012-11-05, and fog is using version 2009-02-01.  Essentially, the long polling code in the gem is not working as intended, and new connections are being opened rapidly before closing almost immediately while waiting for messages.

~~This is a WIP because I need to check into the `CONNECTION_ERRORS` code to see if I need to map that over from the fog-aws gem, or if the aws-sdk gem takes care of that logic for us already.  I think it may be the latter.~~