### PR TITLE
Auto provisioning via rake+CLI, subscriber/topic config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,16 @@
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+Style/Documentation:
+  Enabled: false
+Metrics/LineLength:
+  Max: 100
+Style/SignalException:
+  Enabled: false
+Style/BlockDelimiters:
+  Enabled: false
+PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%w': []
+    '%W': []
+    '%i': []
+    '%I': []

--- a/bin/console
+++ b/bin/console
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "circuitry"
+require 'bundler/setup'
+require 'circuitry'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
+# require 'pry'
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start

--- a/circuitry.gemspec
+++ b/circuitry.gemspec
@@ -6,11 +6,11 @@ require 'circuitry/version'
 Gem::Specification.new do |spec|
   spec.name          = 'circuitry'
   spec.version       = Circuitry::VERSION
-  spec.authors       = ['Matt Huggins']
-  spec.email         = ['matt.huggins@kapost.com']
+  spec.authors       = ['Matt Huggins', 'Brandon Croft']
+  spec.email         = ['matt.huggins@kapost.com', 'brandon@kapost.com']
 
-  spec.summary       = %q{Kapost notification pub/sub and message queue processing.}
-  spec.description   = %q{Amazon SNS publishing and SQS queue processing.}
+  spec.summary       = %q{Decouple ruby applications using Amazon SNS fanout with SQS processing.}
+  spec.description   = %q{A Circuitry publisher application can broadcast events which can be processed independently by Circuitry subscriber applications.}
   spec.homepage      = 'https://github.com/kapost/circuitry'
   spec.license       = 'MIT'
 
@@ -23,15 +23,16 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'retries', '~> 0.0.5'
   spec.add_dependency 'virtus', '~> 1.0'
 
-  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'bundler', '~> 1.8'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.2'
-  spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'codeclimate-test-reporter'
-  spec.add_development_dependency 'redis'
-  spec.add_development_dependency 'mock_redis'
+  spec.add_development_dependency 'connection_pool'
   spec.add_development_dependency 'dalli'
   spec.add_development_dependency 'memcache_mock'
-  spec.add_development_dependency 'connection_pool'
+  spec.add_development_dependency 'mock_redis'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'redis'
+  spec.add_development_dependency 'rspec', '~> 3.2'
+  spec.add_development_dependency 'rspec-its', '~> 1.2'
+  spec.add_development_dependency 'thor'
 end

--- a/exe/circuitry
+++ b/exe/circuitry
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'circuitry'
+require 'circuitry/cli'
+
+Circuitry::CLI.start(ARGV)

--- a/lib/circuitry.rb
+++ b/lib/circuitry.rb
@@ -1,4 +1,4 @@
-require 'circuitry/version'
+require 'circuitry/configuration'
 require 'circuitry/locks/base'
 require 'circuitry/locks/memcache'
 require 'circuitry/locks/memory'
@@ -11,6 +11,7 @@ require 'circuitry/processors/threader'
 require 'circuitry/configuration'
 require 'circuitry/publisher'
 require 'circuitry/subscriber'
+require 'circuitry/version'
 
 module Circuitry
   def self.config(&block)
@@ -23,8 +24,8 @@ module Circuitry
     Publisher.new(options).publish(topic_name, object)
   end
 
-  def self.subscribe(queue, options = {}, &block)
-    Subscriber.new(queue, options).subscribe(&block)
+  def self.subscribe(options = {}, &block)
+    Subscriber.new(options).subscribe(&block)
   end
 
   def self.flush

--- a/lib/circuitry/cli.rb
+++ b/lib/circuitry/cli.rb
@@ -1,0 +1,70 @@
+require 'circuitry/provisioner'
+require 'thor'
+
+module Circuitry
+  class CLI < Thor
+    class_option :verbose, aliases: :v, type: :boolean
+
+    desc 'provision <queue> -t <topic> [<topic> ...]', 'Provision a queue subscribed to one or more topics'
+
+    long_desc <<-END
+      Creates an SQS queue with appropriate SNS access policy along with one or more SNS topics
+      named <topic> that has an SQS subscription for each.
+
+      When the queue already exists, its policy will be added or updated.
+
+      When a topic already exists, it will be ignored.
+
+      When a topic subscription already exists, it will be ignored.
+
+      If no dead letter queue is specified, one will be created by default with the
+      name <queue>-failures
+    END
+
+    option :topics, aliases: :t, type: :array, required: :true
+    option :access_key, aliases: :a
+    option :secret_key, aliases: :s
+    option :dead_letter_queue, aliases: :d
+    option :region, aliases: :r
+
+    def provision(queue_name)
+      with_custom_config(queue_name) do |config|
+        logger = Logger.new(STDOUT)
+        logger.level = Logger::INFO if options['verbose']
+        Circuitry::Provisioner.new(config, logger: logger).run
+      end
+    end
+
+    private
+
+    def say(*args)
+      puts(*args) if options['verbose']
+    end
+
+    def with_custom_config(queue_name, &block)
+      original_values = {}
+      %i[access_key secret_key region subscriber_queue_name subscriber_dead_letter_queue_name publisher_topic_names].each do |sym|
+        original_values[sym] = Circuitry.config.send(sym)
+      end
+
+      assign_options_config(queue_name, original_values)
+
+      block.call(Circuitry.config)
+    ensure
+      restore_config(original_values)
+    end
+
+    def assign_options_config(queue_name, original_values)
+      Circuitry.config.access_key = options.fetch('access_key', original_values[:access_key])
+      Circuitry.config.secret_key = options.fetch('secret_key', original_values[:secret_key])
+      Circuitry.config.region = options.fetch('region', original_values[:region])
+      Circuitry.config.subscriber_queue_name = queue_name
+      Circuitry.config.subscriber_dead_letter_queue_name = options.fetch('dead_letter_queue', "#{queue_name}-failures")
+      Circuitry.config.publisher_topic_names = options['topics']
+    end
+
+    def restore_config(original_values)
+      original_values.keys.each { |key| Circuitry.config.send(:"#{key}=", original_values[key]) }
+    end
+  end
+end

--- a/lib/circuitry/concerns/async.rb
+++ b/lib/circuitry/concerns/async.rb
@@ -29,11 +29,11 @@ module Circuitry
 
       def async=(value)
         value = case value
-          when false, nil then false
-          when true then self.class.default_async_strategy
-          when *self.class.async_strategies then value
-          else raise ArgumentError, "Invalid value `#{value.inspect}`, must be one of #{[true, false].concat(self.class.async_strategies).inspect}"
-        end
+                when false, nil then false
+                when true then self.class.default_async_strategy
+                when *self.class.async_strategies then value
+                else raise ArgumentError, async_value_error(value)
+                end
 
         if value == :fork && !platform_supports_forking?
           raise NotSupportedError, 'Your platform does not support forking'
@@ -43,10 +43,15 @@ module Circuitry
       end
 
       def async?
-        !!async
+        ![nil, false].include?(async)
       end
 
       private
+
+      def async_value_error(value)
+        options = [true, false].concat(self.class.async_strategies).inspect
+        "Invalid value `#{value.inspect}`, must be one of #{options}"
+      end
 
       def platform_supports_forking?
         Process.respond_to?(:fork)

--- a/lib/circuitry/configuration.rb
+++ b/lib/circuitry/configuration.rb
@@ -5,14 +5,18 @@ module Circuitry
   class Configuration
     include Virtus::Model
 
+    attribute :subscriber_queue_name, String
+    attribute :subscriber_dead_letter_queue_name, String
+    attribute :publisher_topic_names, Array[String]
+
     attribute :access_key, String
     attribute :secret_key, String
     attribute :region, String, default: 'us-east-1'
     attribute :logger, Logger, default: Logger.new(STDERR)
     attribute :error_handler
-    attribute :lock_strategy, Object, default: ->(page, attribute) { Circuitry::Locks::Memory.new }
-    attribute :publish_async_strategy, Symbol, default: ->(page, attribute) { :fork }
-    attribute :subscribe_async_strategy, Symbol, default: ->(page, attribute) { :fork }
+    attribute :lock_strategy, Object, default: ->(_page, _attribute) { Circuitry::Locks::Memory.new }
+    attribute :publish_async_strategy, Symbol, default: ->(_page, _attribute) { :fork }
+    attribute :subscribe_async_strategy, Symbol, default: ->(_page, _attribute) { :fork }
     attribute :on_thread_exit
     attribute :on_fork_exit
 
@@ -26,20 +30,23 @@ module Circuitry
       super
     end
 
+    def subscriber_dead_letter_queue_name
+      super || "#{subscriber_queue_name}-failures"
+    end
+
     def aws_options
       {
-          access_key_id:     access_key,
-          secret_access_key: secret_key,
-          region:            region,
+        access_key_id:     access_key,
+        secret_access_key: secret_key,
+        region:            region
       }
     end
 
     private
 
     def validate(value, permitted_values)
-      unless permitted_values.include?(value)
-        raise ArgumentError, "invalid value `#{value}`, must be one of #{permitted_values.inspect}"
-      end
+      return if permitted_values.include?(value)
+      raise ArgumentError, "invalid value `#{value}`, must be one of #{permitted_values.inspect}"
     end
   end
 end

--- a/lib/circuitry/provisioner.rb
+++ b/lib/circuitry/provisioner.rb
@@ -1,0 +1,59 @@
+require 'circuitry/queue_creator'
+require 'circuitry/topic_creator'
+require 'circuitry/subscription_creator'
+
+module Circuitry
+  class Provisioner
+    attr_reader :log
+    attr_reader :config
+
+    def initialize(config, logger: Logger.new(STDOUT))
+      @config = config
+      @log = logger
+    end
+
+    def run
+      queue = create_queue
+      topics = create_topics if queue
+      subscribe_topics(queue, topics) if queue && topics
+    end
+
+    private
+
+    def create_queue
+      safe_aws('Create Queue') do
+        queue = Circuitry::QueueCreator.find_or_create(
+          config.subscriber_queue_name,
+          dead_letter_queue_name: config.subscriber_dead_letter_queue_name
+        )
+        log.info "Created queue #{queue.url}"
+        queue
+      end
+    end
+
+    def create_topics
+      safe_aws('Create Topics') do
+        config.publisher_topic_names.map do |topic_name|
+          topic = Circuitry::TopicCreator.find_or_create(topic_name)
+          log.info "Created topic #{topic.name}"
+          topic
+        end
+      end
+    end
+
+    def subscribe_topics(queue, topics)
+      safe_aws('Subscribe Topics') do
+        Circuitry::SubscriptionCreator.subscribe_all(queue, topics)
+        log.info "Subscribed all topics to #{queue.name}"
+        true
+      end
+    end
+
+    def safe_aws(desc)
+      yield
+    rescue Aws::SQS::Errors::AccessDenied
+      log.fatal("#{desc}: Access denied. Check your configured credentials.")
+      nil
+    end
+  end
+end

--- a/lib/circuitry/queue.rb
+++ b/lib/circuitry/queue.rb
@@ -1,0 +1,27 @@
+require 'circuitry/services/sqs'
+
+module Circuitry
+  class Queue
+    include Services::SQS
+
+    attr_reader :url
+
+    def initialize(url)
+      @url = url
+    end
+
+    def name
+      url.split('/').last
+    end
+
+    def arn
+      @arn ||= attribute('QueueArn')
+    end
+
+    private
+
+    def attribute(name)
+      sqs.get_queue_attributes(queue_url: url, attribute_names: [name]).attributes[name]
+    end
+  end
+end

--- a/lib/circuitry/queue_creator.rb
+++ b/lib/circuitry/queue_creator.rb
@@ -1,0 +1,50 @@
+require 'circuitry/services/sqs'
+require 'circuitry/queue'
+
+module Circuitry
+  class QueueCreator
+    include Services::SQS
+
+    attr_reader :queue_name
+
+    def self.find_or_create(queue_name, dead_letter_queue_name: nil, max_receive_count: 8 )
+      creator = new(queue_name)
+      result = creator.create_queue
+      creator.create_dead_letter_queue(dead_letter_queue_name, max_receive_count) if dead_letter_queue_name
+      result
+    end
+
+    def initialize(queue_name)
+      @queue_name = queue_name
+    end
+
+    def create_queue
+      @_queue ||= Queue.new(create_primary_queue_internal)
+    end
+
+    def create_dead_letter_queue(name, max_receive_count)
+      @_dl_queue ||= Queue.new(create_dl_queue_internal(name, max_receive_count))
+    end
+
+    private
+
+    def create_dl_queue_internal(name, max_receive_count)
+      dl_url = sqs.create_queue(queue_name: name).queue_url
+      dl_arn = sqs.get_queue_attributes(queue_url: dl_url, attribute_names: ['QueueArn']).attributes['QueueArn']
+
+      sqs.set_queue_attributes(queue_url: create_queue.url, attributes: build_redrive_policy(dl_arn, max_receive_count))
+      dl_url
+    end
+
+    def build_redrive_policy(deadletter_arn, max_receive_count)
+      {
+        'RedrivePolicy' => %({"maxReceiveCount":"#{max_receive_count}", "deadLetterTargetArn":"#{deadletter_arn}"})
+      }
+    end
+
+    def create_primary_queue_internal
+      attributes = { 'VisibilityTimeout' => (30 * 60).to_s }
+      sqs.create_queue(queue_name: queue_name, attributes: attributes).queue_url
+    end
+  end
+end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -14,36 +14,33 @@ module Circuitry
     attr_reader :queue, :timeout, :wait_time, :batch_size, :lock
 
     DEFAULT_OPTIONS = {
-        lock: true,
-        async: false,
-        timeout: 15,
-        wait_time: 10,
-        batch_size: 10,
+      lock: true,
+      async: false,
+      timeout: 15,
+      wait_time: 10,
+      batch_size: 10
     }.freeze
 
     CONNECTION_ERRORS = [
-        Aws::SQS::Errors::ServiceError,
+      Aws::SQS::Errors::ServiceError
     ].freeze
 
-    def initialize(queue, options = {})
-      raise ArgumentError.new('queue cannot be nil') if queue.nil?
-
+    def initialize(options = {})
       options = DEFAULT_OPTIONS.merge(options)
 
       self.subscribed = false
-      self.queue = queue
-      self.lock = options[:lock]
-      self.async = options[:async]
-      self.timeout = options[:timeout]
-      self.wait_time = options[:wait_time]
-      self.batch_size = options[:batch_size]
+
+      self.queue = QueueCreator.find_or_create(Circuitry.config.subscriber_queue_name).url
+      %i[lock async timeout wait_time batch_size].each do |sym|
+        send(:"#{sym}=", options[sym])
+      end
 
       trap_signals
     end
 
     def subscribe(&block)
-      raise ArgumentError.new('block required') if block.nil?
-      raise SubscribeError.new('AWS configuration is not set') unless can_subscribe?
+      raise ArgumentError, 'block required' if block.nil?
+      raise SubscribeError, 'AWS configuration is not set' unless can_subscribe?
 
       logger.info("Subscribing to queue: #{queue}")
 
@@ -54,7 +51,7 @@ module Circuitry
       logger.info("Unsubscribed from queue: #{queue}")
     rescue *CONNECTION_ERRORS => e
       logger.error("Connection error to queue: #{queue}: #{e}")
-      raise SubscribeError.new(e)
+      raise SubscribeError, e.message
     end
 
     def subscribed?
@@ -76,16 +73,21 @@ module Circuitry
 
     def lock=(value)
       value = case value
-        when true then Circuitry.config.lock_strategy
-        when false then Circuitry::Locks::NOOP.new
-        when Circuitry::Locks::Base then value
-        else raise ArgumentError, "Invalid value `#{value}`, must be one of `true`, `false`, or instance of `#{Circuitry::Locks::Base}`"
-      end
+              when true then Circuitry.config.lock_strategy
+              when false then Circuitry::Locks::NOOP.new
+              when Circuitry::Locks::Base then value
+              else raise ArgumentError, lock_value_error(value)
+              end
 
       @lock = value
     end
 
     private
+
+    def lock_value_error(value)
+      opts = Circuitry::Locks::Base
+      "Invalid value `#{value}`, must be one of `true`, `false`, or instance of `#{opts}`"
+    end
 
     def trap_signals
       trap('SIGINT') do
@@ -109,17 +111,19 @@ module Circuitry
     end
 
     def process_messages(messages, &block)
-      messages.each do |message|
-        process = -> do
-          process_message(message, &block)
-        end
-
-        if async?
-          process_asynchronously(&process)
-        else
-          process.call
-        end
+      if async?
+        process_messages_asynchronously(messages, &block)
+      else
+        process_messages_synchronously(messages, &block)
       end
+    end
+
+    def process_messages_asynchronously(messages, &block)
+      messages.each { |message| process_asynchronously(& -> { process_message(message, &block) }) }
+    end
+
+    def process_messages_synchronously(messages, &block)
+      messages.each { |message| process_message(message, &block) }
     end
 
     def process_message(message, &block)
@@ -134,20 +138,35 @@ module Circuitry
     end
 
     def handle_message(message, &block)
-      if lock.soft_lock(message.id)
+      handled = try_with_lock(message.id) do
         begin
+          # TODO: Don't use ruby timeout.
+          # http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/
           Timeout.timeout(timeout) do
             block.call(message.body, message.topic.name)
           end
         rescue => e
-          lock.unlock(message.id)
           logger.error("Error handling message #{message.id}: #{e}")
           raise e
         end
+      end
 
-        lock.hard_lock(message.id)
+      logger.info("Ignoring duplicate message #{message.id}") unless handled
+    end
+
+    def try_with_lock(handle)
+      if lock.soft_lock(handle)
+        begin
+          yield
+        rescue => e
+          lock.unlock(handle)
+          raise e
+        end
+
+        lock.hard_lock(handle)
+        true
       else
-        logger.info("Ignoring duplicate message #{message.id}")
+        false
       end
     end
 

--- a/lib/circuitry/subscription_creator.rb
+++ b/lib/circuitry/subscription_creator.rb
@@ -1,0 +1,60 @@
+require 'circuitry/services/sns'
+require 'circuitry/topic'
+
+module Circuitry
+  class SubscriptionCreator
+    include Services::SNS
+    include Services::SQS
+
+    attr_reader :queue
+    attr_reader :topics
+
+    def self.subscribe_all(queue, topics)
+      new(queue, topics).subscribe_all
+    end
+
+    def initialize(queue, topics)
+      raise ArgumentError, 'queue must be a Circuitry::Queue' unless queue.is_a?(Circuitry::Queue)
+      raise ArgumentError, 'topics must be an array' unless topics.is_a?(Array)
+
+      @queue = queue
+      @topics = topics
+    end
+
+    def subscribe_all
+      topics.each do |topic|
+        sns.subscribe(topic_arn: topic.arn, endpoint: queue.arn, protocol: 'sqs')
+      end
+      sqs.set_queue_attributes(
+        queue_url: queue.url,
+        attributes: build_policy
+      )
+    end
+
+    private
+
+    def build_policy
+      # The aws ruby SDK doesn't have a policy builder :{
+      {
+        'Policy' => {
+          'Version'   => '2012-10-17',
+          'Id'        => '#{queue.arn}/SNSPolicy',
+          'Statement' => topics.map { |t| build_policy_statement(t) }
+        }.to_json
+      }
+    end
+
+    def build_policy_statement(topic)
+      {
+        'Sid'       => "Sid#{topic.name}",
+        'Effect'    => 'Allow',
+        'Principal' => { 'AWS' => '*' },
+        'Action'    => 'SQS:SendMessage',
+        'Resource'  => queue.arn,
+        'Condition' => {
+          'ArnEquals' => { 'aws:SourceArn' => topic.arn }
+        }
+      }
+    end
+  end
+end

--- a/lib/circuitry/topic_creator.rb
+++ b/lib/circuitry/topic_creator.rb
@@ -16,10 +16,10 @@ module Circuitry
     end
 
     def topic
-      return @topic if defined?(@topic)
+      return @_topic if defined?(@_topic)
 
       response = sns.create_topic(name: topic_name)
-      @topic = Topic.new(response.topic_arn)
+      @_topic = Topic.new(response.topic_arn)
     end
   end
 end

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '1.4.1'
+  VERSION = '2.0.0'
 end

--- a/lib/tasks/circuitry_tasks.rake
+++ b/lib/tasks/circuitry_tasks.rake
@@ -1,0 +1,11 @@
+require 'circuitry/provisioner'
+
+namespace :circuitry do
+  desc 'Create subscriber queues and subscribe queue to topics'
+  task setup: :environment do
+    logger = Logger.new(STDOUT)
+    logger.level = Logger::INFO
+
+    Circuitry::Provisioner.new(Circuitry.config, logger: logger).run
+  end
+end

--- a/spec/circuitry/cli_spec.rb
+++ b/spec/circuitry/cli_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+require 'circuitry/cli'
+
+RSpec.describe Circuitry::CLI do
+  subject { described_class }
+
+  describe '#provision' do
+    before do
+      allow(Circuitry::QueueCreator).to receive(:find_or_create).and_return(queue)
+      allow(Circuitry::TopicCreator).to receive(:find_or_create).and_return(topic)
+      allow(Circuitry::SubscriptionCreator).to receive(:subscribe_all).and_return(true)
+
+      subject.start(command.split)
+    end
+
+    let(:queue) { Circuitry::Queue.new('http://sqs.amazontest.com/example') }
+    let(:topic) { Circuitry::Topic.new('arn:aws:sns:us-east-1:123456789012:some-topic-name') }
+
+    describe 'vanilla command' do
+      let(:command) { 'provision example -t topic1 topic2' }
+
+      it 'creates primary and dead letter queues' do
+        expect(Circuitry::QueueCreator).to have_received(:find_or_create).once.with('example', hash_including(dead_letter_queue_name: 'example-failures'))
+      end
+
+      it 'creates each topic' do
+        expect(Circuitry::TopicCreator).to have_received(:find_or_create).twice
+      end
+
+      it 'subscribes to all topics' do
+        expect(Circuitry::SubscriptionCreator).to have_received(:subscribe_all).once.with(queue, [topic, topic])
+      end
+    end
+
+    describe 'no queue given' do
+      let(:command) { 'provision' }
+
+      it 'does nothing' do
+        expect(Circuitry::QueueCreator).to_not have_received(:find_or_create)
+      end
+    end
+
+    describe 'no topics given' do
+      let(:command) { 'provision example' }
+
+      it 'does not create queue' do
+        expect(Circuitry::QueueCreator).to_not have_received(:find_or_create)
+      end
+
+      it 'does not create topics' do
+        expect(Circuitry::TopicCreator).to_not have_received(:find_or_create)
+      end
+    end
+  end
+end

--- a/spec/circuitry/configuration_spec.rb
+++ b/spec/circuitry/configuration_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe Circuitry::Configuration, type: :model do
     it_behaves_like 'a validated setting', Circuitry::Subscriber.async_strategies, :subscribe_async_strategy
   end
 
+  describe '#subscriber_queue_name' do
+    it 'sets #subscriber_dead_letter_queue_name' do
+      expect {
+        subject.subscriber_queue_name = 'awesome'
+      }.to change(subject, :subscriber_dead_letter_queue_name).to('awesome-failures')
+    end
+
+    context 'subscriber_dead_letter_queue_name is set' do
+      before do
+        subject.subscriber_dead_letter_queue_name = 'dawson'
+      end
+
+      it 'does not set #subscriber_dead_letter_queue_name' do
+        expect {
+          subject.subscriber_queue_name = 'awesome'
+        }.to_not change(subject, :subscriber_dead_letter_queue_name)
+      end
+    end
+  end
+
   describe '#aws_options' do
     before do
       subject.access_key = 'access_key'

--- a/spec/circuitry/queue_creator_spec.rb
+++ b/spec/circuitry/queue_creator_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe Circuitry::QueueCreator, type: :model do
+  describe '.find_or_create' do
+    subject { described_class }
+    before do
+      allow_any_instance_of(subject).to receive(:sqs).and_return(mock_sqs)
+    end
+
+    let(:queue_url) { 'http://sqs.amazontest.com/howdy' }
+    let(:queue_arn) { 'amazon:test:howdy' }
+    let(:queue_attributes) { OpenStruct.new(attributes: { 'QueueArn' => queue_arn }) }
+    let(:create_queue_response) { OpenStruct.new(queue_url: queue_url) }
+    let(:mock_sqs) { double('SQS', create_queue: create_queue_response, set_queue_attributes: true, get_queue_attributes: queue_attributes) }
+
+    it 'creates and returns primary queue' do
+      queue = subject.find_or_create('howdy')
+      expect(queue.name).to eql('howdy')
+    end
+
+    context 'when dead letter queue name option is given' do
+      it 'creates dead letter' do
+        subject.find_or_create('howdy', dead_letter_queue_name: 'howdy-failures')
+        expect(mock_sqs).to have_received(:create_queue).with(hash_including(queue_name: 'howdy-failures'))
+      end
+
+      it 'sets redrive policy on primary queue' do
+        subject.find_or_create('howdy', dead_letter_queue_name: 'howdy-failures')
+        expect(mock_sqs).to have_received(:set_queue_attributes).with(hash_including(queue_url: queue_url, attributes: { 'RedrivePolicy' => "{\"maxReceiveCount\":\"8\", \"deadLetterTargetArn\":\"#{queue_arn}\"}"}))
+      end
+    end
+
+    it 'creates queue with visibility timeout' do
+      subject.find_or_create('howdy')
+      expect(mock_sqs).to have_received(:create_queue).with(hash_including(queue_name: 'howdy', attributes: { 'VisibilityTimeout' => '1800' }))
+    end
+  end
+end

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -1,31 +1,19 @@
 require 'spec_helper'
 
 RSpec.describe Circuitry::Subscriber, type: :model do
-  subject { described_class.new(queue, options) }
+  subject { described_class.new(options) }
 
   let(:queue) { 'https://sqs.amazon.com/account/queue' }
   let(:options) { {} }
 
   it { is_expected.to be_a Circuitry::Concerns::Async }
 
+  before do
+    allow(Circuitry::QueueCreator).to receive(:find_or_create).and_return(double('Queue', url: queue))
+  end
+
   describe '.new' do
     subject { described_class }
-
-    describe 'when queue is set' do
-      let(:queue) { 'https://sqs.amazon.com/account/queue' }
-
-      it 'does not raise an error' do
-        expect { subject.new(queue) }.to_not raise_error
-      end
-    end
-
-    describe 'when queue is not set' do
-      let(:queue) { nil }
-
-      it 'raises an error' do
-        expect { subject.new(queue) }.to raise_error(ArgumentError)
-      end
-    end
 
     describe 'when lock' do
       subject { described_class }
@@ -34,11 +22,11 @@ RSpec.describe Circuitry::Subscriber, type: :model do
 
       shared_examples_for 'a valid lock strategy' do |lock_class|
         it 'does not raise an error' do
-          expect { subject.new(queue, options) }.to_not raise_error
+          expect { subject.new(options) }.to_not raise_error
         end
 
         it 'sets the lock strategy' do
-          subscriber = subject.new(queue, options)
+          subscriber = subject.new(options)
           expect(subscriber.lock).to be_a lock_class
         end
       end
@@ -62,7 +50,7 @@ RSpec.describe Circuitry::Subscriber, type: :model do
         let(:lock) { 'invalid' }
 
         it 'raises an error' do
-          expect { subject.new(queue, options) }.to raise_error(ArgumentError)
+          expect { subject.new(options) }.to raise_error(ArgumentError)
         end
       end
     end

--- a/spec/circuitry/subscription_creator_spec.rb
+++ b/spec/circuitry/subscription_creator_spec.rb
@@ -1,0 +1,37 @@
+require 'json'
+require 'spec_helper'
+
+RSpec::Matchers.define :policy_statement_count_matcher do |count|
+  match do |actual|
+    JSON.parse(actual[:attributes]['Policy'])['Statement'].length == count
+  end
+end
+
+RSpec.describe Circuitry::SubscriptionCreator do
+  describe '.subscribe_all' do
+    subject { described_class }
+
+    before do
+      allow_any_instance_of(subject).to receive(:sqs).and_return(mock_sqs)
+      allow_any_instance_of(subject).to receive(:sns).and_return(mock_sns)
+      allow(queue).to receive(:arn).and_return(queue_arn)
+    end
+
+    let(:mock_sns) { double('SNS', subscribe: true) }
+    let(:mock_sqs) { double('SQS', set_queue_attributes: true) }
+
+    let(:topics) { (1..3).map { |index| Circuitry::Topic.new("arn:aws:sns:us-east-1:123456789012:some-topic-name#{index+1}") } }
+    let(:queue) { Circuitry::Queue.new('http://amazontest.com/howdy') }
+    let(:queue_arn) { 'arn:aws:sqs:us-east-1:123456789012:howdy' }
+
+    it 'subscribes each topic to the queue' do
+      subject.subscribe_all(queue, topics)
+      expect(mock_sns).to have_received(:subscribe).thrice.with(hash_including(endpoint: queue_arn, protocol: 'sqs'))
+    end
+
+    it 'sets policy attribute on sqs queue for each topic' do
+      subject.subscribe_all(queue, topics)
+      expect(mock_sqs).to have_received(:set_queue_attributes).once.with(policy_statement_count_matcher(3))
+    end
+  end
+end

--- a/spec/circuitry_spec.rb
+++ b/spec/circuitry_spec.rb
@@ -33,14 +33,18 @@ RSpec.describe Circuitry, type: :model do
   end
 
   describe '.subscribe' do
-    it 'delegates to a new subscriber' do
-      subscriber = double('Subscriber', subscribe: true)
-      queue = 'https://sqs.amazon.com/account/queue'
-      block = -> { }
-      options = { foo: 'bar' }
+    let(:subscriber) { double('Subscriber', subscribe: true) }
+    let(:queue) { 'https://sqs.amazon.com/account/queue' }
+    let(:options) { { foo: 'bar' } }
 
-      allow(Circuitry::Subscriber).to receive(:new).with(queue, options).and_return(subscriber)
-      subject.subscribe(queue, options, &block)
+    before do
+      allow(Circuitry::Subscriber).to receive(:new).with(options).and_return(subscriber)
+      allow(Circuitry::QueueCreator).to receive(:find_or_create).and_return(double('Queue', url: queue))
+    end
+
+    it 'delegates to a new subscriber' do
+      block = -> {}
+      subject.subscribe(options, &block)
       expect(subscriber).to have_received(:subscribe).with(no_args, &block)
     end
   end


### PR DESCRIPTION
Adds a few QoL fixes to Amazon provisioning

- Resolves competing provisioning code between CLI and rake task in previous PR
- Changes the interface for Circuitry.subscribe to not use a queue url in favor of a config variable (circuitry subscribers should only have one queue), and bumps version to 2.0 due to this change.
- Resolves a bunch of rubocop issues