### PR TITLE
Added flush middleware

### DIFF
--- a/lib/circuitry/config/shared_settings.rb
+++ b/lib/circuitry/config/shared_settings.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'circuitry/middleware/entries/flush'
 
 module Circuitry
   class ConfigError < StandardError; end
@@ -17,8 +18,12 @@ module Circuitry
       end
 
       def middleware
-        @_middleware ||= Circuitry::Middleware::Chain.new
+        @_middleware ||= Middleware::Chain.new do |middleware|
+          middleware.add Middleware::Entries::Flush
+        end
+
         yield @_middleware if block_given?
+
         @_middleware
       end
 

--- a/lib/circuitry/middleware/chain.rb
+++ b/lib/circuitry/middleware/chain.rb
@@ -5,6 +5,10 @@ module Circuitry
     class Chain
       include Enumerable
 
+      def initialize
+        yield self if block_given?
+      end
+
       def each(&block)
         entries.each(&block)
       end

--- a/lib/circuitry/middleware/entries/flush.rb
+++ b/lib/circuitry/middleware/entries/flush.rb
@@ -1,0 +1,16 @@
+module Circuitry
+  module Middleware
+    module Entries
+      class Flush
+        def initialize(_options = {})
+        end
+
+        def call(_topic, _message)
+          yield
+        ensure
+          Circuitry.flush
+        end
+      end
+    end
+  end
+end

--- a/spec/circuitry/middleware/entries/flush_spec.rb
+++ b/spec/circuitry/middleware/entries/flush_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe Circuitry::Middleware::Entries::Flush do
+  subject { described_class.new(options) }
+
+  let(:options) { {} }
+
+  describe '#call' do
+    def call
+      subject.call('topic', 'message', &block)
+    end
+
+    describe 'when processing succeeds' do
+      let(:block) { ->{} }
+
+      it 'flushes' do
+        expect(Circuitry).to receive(:flush)
+        call
+      end
+    end
+
+    describe 'when processing fails' do
+      let(:block) { ->{ raise StandardError, 'test failure' } }
+
+      it 'flushes' do
+        expect(Circuitry).to receive(:flush)
+        call rescue nil
+      end
+
+      it 'raises the error' do
+        expect { call }.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
@brandonc @ianisborn This adds a new flush middleware to the publisher & subscriber middleware chains.  This ensures that any new circuitry messages enqueued while receiving or sending another message also gets delivered.  Previously, this had to be handled in the following manner (like Ian had to include in studio):

```ruby
Circuitry.subscribe do |message, topic|
  handle(handler, topic_name(topic), message)
  Circuitry.flush
end
```