### PR TITLE
Added mocks for third-party testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,16 @@ your middleware:
 * `#clear`: Removes all middleware classes from the chain.
   * `middleware.clear`
 
+## Testing
+
+Circuitry provides a simple option for testing publishing and subscribing without actually hitting
+Amazon services.  Inside your test suite (e.g.: `spec_helper.rb`), just make sure you include the
+following line:
+
+```ruby
+require 'circuitry/testing'
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/lib/circuitry/testing.rb
+++ b/lib/circuitry/testing.rb
@@ -1,0 +1,15 @@
+require 'circuitry'
+
+module Circuitry
+  class Publisher
+    def publish(_topic_name, _object)
+      # noop
+    end
+  end
+
+  class Subscriber
+    def subscribe(&_block)
+      # noop
+    end
+  end
+end


### PR DESCRIPTION
@brandonc This provides simple mocking for tests in third-party apps.  (We've got a custom mock in studio at the moment, which this would take the place of.)