### PR TITLE
Fixed readme example for production topic names

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ development:
 production:
   publisher:
     topic_names:
-      - brandonc-appname-user-create
-      - brandonc-appname-user-destroy
+      - production-appname-user-create
+      - production-appname-user-destroy
   subscriber:
     queue_name: "production-appname"
     dead_letter_queue_name: "production-appname-failures"


### PR DESCRIPTION
@brandonc Your yaml example in the readme had bad topic names for the production environment.  This should help to clarify how this is expected to work.