### PR TITLE
Updated to permit subscription only (no queue name requirement)

### DIFF
--- a/lib/circuitry/provisioning/provisioner.rb
+++ b/lib/circuitry/provisioning/provisioner.rb
@@ -11,10 +11,8 @@ module Circuitry
 
       def run
         queue = create_queue
-        return unless queue
-
+        subscribe_topics(queue, create_topics(:subscriber, subscriber_config.topic_names)) if queue
         create_topics(:publisher, publisher_config.topic_names)
-        subscribe_topics(queue, create_topics(:subscriber, subscriber_config.topic_names))
       end
 
       private
@@ -30,6 +28,11 @@ module Circuitry
       end
 
       def create_queue
+        if subscriber_config.queue_name.nil?
+          logger.info 'Skipping queue creation: queue_name is not configured'
+          return nil
+        end
+
         safe_aws('Create queue') do
           queue = QueueCreator.find_or_create(
             subscriber_config.queue_name,

--- a/spec/circuitry/provisioning/provisioner_spec.rb
+++ b/spec/circuitry/provisioning/provisioner_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe Circuitry::Provisioning::Provisioner do
+  subject { described_class.new(logger) }
+
+  let(:logger) { double('Logger', info: nil, fatal: nil) }
+
+  describe '#run' do
+    let(:queue) { Circuitry::Queue.new('my_queue_name') }
+    let(:topic) { Circuitry::Topic.new('my_topic_arn') }
+
+    before do
+      Circuitry.subscriber_config.topic_names = %w[my_topic_name1 my_topic_name2]
+      Circuitry.publisher_config.topic_names = %w[my_sub_topic_name]
+
+      allow(Circuitry::Provisioning::QueueCreator).to receive(:find_or_create).and_return(queue)
+      allow(Circuitry::Provisioning::TopicCreator).to receive(:find_or_create).and_return(topic)
+      allow(Circuitry::Provisioning::SubscriptionCreator).to receive(:subscribe_all).and_return(true)
+
+    end
+
+    describe 'when queue name is set' do
+      before do
+        Circuitry.subscriber_config.queue_name = 'my_queue_name'
+        subject.run
+      end
+
+      it 'creates a queue' do
+        expect(Circuitry::Provisioning::QueueCreator).to have_received(:find_or_create).once.with(Circuitry.subscriber_config.queue_name,
+          dead_letter_queue_name: 'my_queue_name-failures',
+          visibility_timeout: Circuitry.subscriber_config.visibility_timeout,
+          max_receive_count: Circuitry.subscriber_config.max_receive_count
+        )
+      end
+
+      it 'creates publisher topics' do
+        expect(Circuitry::Provisioning::TopicCreator).to have_received(:find_or_create).once.with('my_sub_topic_name')
+      end
+
+      it 'creates subscriber topics' do
+        expect(Circuitry::Provisioning::TopicCreator).to have_received(:find_or_create).once.with('my_topic_name1')
+        expect(Circuitry::Provisioning::TopicCreator).to have_received(:find_or_create).once.with('my_topic_name2')
+      end
+
+      it 'subscribes subscriber topics to queue' do
+        expect(Circuitry::Provisioning::SubscriptionCreator).to have_received(:subscribe_all).once.with(queue, [topic, topic])
+      end
+    end
+
+    describe 'when queue name is not set' do
+      before do
+        Circuitry.subscriber_config.queue_name = nil
+        subject.run
+      end
+
+      it 'does not create a queue' do
+        expect(Circuitry::Provisioning::QueueCreator).to_not have_received(:find_or_create)
+      end
+
+      it 'creates publisher topics' do
+        expect(Circuitry::Provisioning::TopicCreator).to have_received(:find_or_create).once.with('my_sub_topic_name')
+      end
+
+      it 'does not create subscriber topics' do
+        expect(Circuitry::Provisioning::TopicCreator).to_not have_received(:find_or_create).with('my_topic_name1')
+        expect(Circuitry::Provisioning::TopicCreator).to_not have_received(:find_or_create).with('my_topic_name2')
+      end
+
+      it 'does not subscribe subscriber topics to queue' do
+        expect(Circuitry::Provisioning::SubscriptionCreator).to_not have_received(:subscribe_all)
+      end
+    end
+  end
+end

--- a/spec/circuitry/provisioning/subscription_creator_spec.rb
+++ b/spec/circuitry/provisioning/subscription_creator_spec.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'spec_helper'
 
-RSpec::Matchers.define :policy_statement_count_matcher do |count|
+RSpec::Matchers.define :policy_statement_count do |count|
   match do |actual|
     JSON.parse(actual[:attributes]['Policy'])['Statement'].length == count
   end
@@ -20,7 +20,7 @@ RSpec.describe Circuitry::Provisioning::SubscriptionCreator do
     let(:mock_sns) { double('SNS', subscribe: true) }
     let(:mock_sqs) { double('SQS', set_queue_attributes: true) }
 
-    let(:topics) { (1..3).map { |index| Circuitry::Topic.new("arn:aws:sns:us-east-1:123456789012:some-topic-name#{index+1}") } }
+    let(:topics) { (1..3).map { |index| Circuitry::Topic.new("arn:aws:sns:us-east-1:123456789012:some-topic-name#{index + 1}") } }
     let(:queue) { Circuitry::Queue.new('http://amazontest.com/howdy') }
     let(:queue_arn) { 'arn:aws:sqs:us-east-1:123456789012:howdy' }
 
@@ -31,7 +31,7 @@ RSpec.describe Circuitry::Provisioning::SubscriptionCreator do
 
     it 'sets policy attribute on sqs queue for each topic' do
       subject.subscribe_all(queue, topics)
-      expect(mock_sqs).to have_received(:set_queue_attributes).once.with(policy_statement_count_matcher(3))
+      expect(mock_sqs).to have_received(:set_queue_attributes).once.with(policy_statement_count(3))
     end
   end
 end


### PR DESCRIPTION
@kapost/core This change permits an app to only publish without subscribing to a queue.  Currently, the provisioner breaks down because it expects queue_name to always be set.