### PR TITLE
Revisit flush middleware on subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Circuitry 3.1.2 (Unreleased)
+
+* Reimplemented subscriber-only flush middleware. *Matt Huggins*
+
 ## Circuitry 3.1.1 (Mar 3, 2016)
 
 * Removed flush middleware. *Matt Huggins*

--- a/README.md
+++ b/README.md
@@ -555,6 +555,16 @@ your middleware:
 * `#clear`: Removes all middleware classes from the chain.
   * `middleware.clear`
 
+### Default Subscriber Middleware:
+
+* `Circuitry::Middleware::Entries::Flush`: ensures any pending async publishes are run after a
+  message is received.  Useful for publishes that happen as a result of processing received
+  messages.
+
+### Default Publisher Middleware:
+
+None.
+
 ## Testing
 
 Circuitry provides a simple option for testing publishing and subscribing without actually hitting

--- a/lib/circuitry/config/publisher_settings.rb
+++ b/lib/circuitry/config/publisher_settings.rb
@@ -11,6 +11,12 @@ module Circuitry
         validate_setting(value, Publisher.async_strategies)
         super
       end
+
+      def middleware
+        @middleware ||= Middleware::Chain.new
+        yield @middleware if block_given?
+        @middleware
+      end
     end
   end
 end

--- a/lib/circuitry/config/shared_settings.rb
+++ b/lib/circuitry/config/shared_settings.rb
@@ -16,12 +16,6 @@ module Circuitry
         base.attribute :async_strategy, Symbol, default: ->(_page, _att) { :fork }
       end
 
-      def middleware
-        @_middleware ||= Middleware::Chain.new
-        yield @_middleware if block_given?
-        @_middleware
-      end
-
       def aws_options
         {
           access_key_id:     access_key,

--- a/lib/circuitry/config/subscriber_settings.rb
+++ b/lib/circuitry/config/subscriber_settings.rb
@@ -1,5 +1,6 @@
 require 'virtus'
 require 'circuitry/config/shared_settings'
+require 'circuitry/middleware/entries/flush'
 
 module Circuitry
   module Config
@@ -26,6 +27,16 @@ module Circuitry
         unless value.is_a?(Circuitry::Locks::Base)
           raise ConfigError, "invalid lock strategy \"#{value.inspect}\""
         end
+      end
+
+      def middleware
+        @middleware ||= Middleware::Chain.new do |middleware|
+          middleware.add Middleware::Entries::Flush
+        end
+
+        yield @middleware if block_given?
+
+        @middleware
       end
     end
   end

--- a/lib/circuitry/middleware/entries/flush.rb
+++ b/lib/circuitry/middleware/entries/flush.rb
@@ -1,0 +1,16 @@
+module Circuitry
+  module Middleware
+    module Entries
+      class Flush
+        def initialize(_options = {})
+        end
+
+        def call(_topic, _message)
+          yield
+        ensure
+          Circuitry.flush
+        end
+      end
+    end
+  end
+end

--- a/spec/circuitry/config/publisher_settings_spec.rb
+++ b/spec/circuitry/config/publisher_settings_spec.rb
@@ -26,4 +26,12 @@ RSpec.describe Circuitry::Config::PublisherSettings do
       expect(subject.aws_options).to eq(access_key_id: 'access_key', secret_access_key: 'secret_key', region: 'region')
     end
   end
+
+  describe '#middleware' do
+    it_behaves_like 'middleware settings'
+
+    it 'does not include flush middleware' do
+      expect(subject.middleware.exists?(Circuitry::Middleware::Entries::Flush)).to be false
+    end
+  end
 end

--- a/spec/circuitry/config/subscriber_settings_spec.rb
+++ b/spec/circuitry/config/subscriber_settings_spec.rb
@@ -24,4 +24,12 @@ RSpec.describe Circuitry::Config::SubscriberSettings do
       end
     end
   end
+
+  describe '#middleware' do
+    it_behaves_like 'middleware settings'
+
+    it 'includes flush middleware' do
+      expect(subject.middleware.exists?(Circuitry::Middleware::Entries::Flush)).to be true
+    end
+  end
 end

--- a/spec/circuitry/middleware/chain_spec.rb
+++ b/spec/circuitry/middleware/chain_spec.rb
@@ -1,24 +1,5 @@
 require 'spec_helper'
 
-class TestMiddleware
-  attr_accessor :log
-
-  def initialize(log: [])
-    self.log = log
-  end
-
-  def call(*args)
-    log << 'before'
-    log.concat(args)
-    yield
-  ensure
-    log << 'after'
-  end
-end
-
-class TestMiddleware2 < TestMiddleware
-end
-
 RSpec.describe Circuitry::Middleware::Chain do
   def entry
     subject.detect { |entry| entry.klass == TestMiddleware }

--- a/spec/circuitry/middleware/entries/flush_spec.rb
+++ b/spec/circuitry/middleware/entries/flush_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe Circuitry::Middleware::Entries::Flush do
+  subject { described_class.new(options) }
+
+  let(:options) { {} }
+
+  describe '#call' do
+    def call
+      subject.call('topic', 'message', &block)
+    end
+
+    describe 'when processing succeeds' do
+      let(:block) { ->{} }
+
+      it 'flushes' do
+        expect(Circuitry).to receive(:flush)
+        call
+      end
+    end
+
+    describe 'when processing fails' do
+      let(:block) { ->{ raise StandardError, 'test failure' } }
+
+      it 'flushes' do
+        expect(Circuitry).to receive(:flush)
+        call rescue nil
+      end
+
+      it 'raises the error' do
+        expect { call }.to raise_error
+      end
+    end
+  end
+end

--- a/spec/fixtures/test_middleware.rb
+++ b/spec/fixtures/test_middleware.rb
@@ -1,0 +1,18 @@
+class TestMiddleware
+  attr_accessor :log
+
+  def initialize(log: [])
+    self.log = log
+  end
+
+  def call(*args)
+    log << 'before'
+    log.concat(args)
+    yield
+  ensure
+    log << 'after'
+  end
+end
+
+class TestMiddleware2 < TestMiddleware
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ require 'securerandom'
 # of increasing the boot-up time by auto-requiring all files in the support
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
+Dir[File.expand_path('spec/fixtures/**/*.rb')].each { |f| require f }
 Dir[File.expand_path('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|

--- a/spec/support/examples/settings_examples.rb
+++ b/spec/support/examples/settings_examples.rb
@@ -32,3 +32,24 @@ RSpec.shared_examples_for 'a validated setting' do |permitted_values, setting_na
     end
   end
 end
+
+RSpec.shared_examples_for 'middleware settings' do
+  it 'returns a middleware chain' do
+    expect(subject.middleware).to be_a Circuitry::Middleware::Chain
+  end
+
+  it 'yields block' do
+    called = false
+    block = ->(_chain) { called = true }
+
+    expect { subject.middleware(&block) }.to change { called }.to(true)
+  end
+
+  it 'preserves the middleware chain' do
+    subject.middleware do |chain|
+      chain.add TestMiddleware
+    end
+
+    expect(subject.middleware.exists?(TestMiddleware)).to be true
+  end
+end


### PR DESCRIPTION
@brandonc I've been thinking about this since we talked yesterday.  This middleware works as a subscriber middleware, but not as a publisher middleware.  The stack overflow issue will not occur on the subscriber side (no publish -> flush -> publish loop), and I think it actually does make sense here.  Would like to revisit.  No rush.