### PR TITLE
Updated publisher retries to handle internal error with backoff

### DIFF
--- a/lib/circuitry/publisher.rb
+++ b/lib/circuitry/publisher.rb
@@ -16,7 +16,8 @@ module Circuitry
     }.freeze
 
     CONNECTION_ERRORS = [
-      Seahorse::Client::NetworkingError
+      ::Seahorse::Client::NetworkingError,
+      ::Aws::SNS::Errors::InternalFailure
     ].freeze
 
     attr_reader :timeout
@@ -59,7 +60,7 @@ module Circuitry
             logger.warn("Error publishing attempt ##{attempt_number}: #{error.class} (#{error.message}); retrying...")
           end
 
-          with_retries(max_tries: 3, handler: handler, rescue: CONNECTION_ERRORS, base_sleep_seconds: 0, max_sleep_seconds: 0) do
+          with_retries(max_tries: 3, handler: handler, rescue: CONNECTION_ERRORS, base_sleep_seconds: 0.05, max_sleep_seconds: 0.25) do
             topic = Topic.find(topic_name)
             sns.publish(topic_arn: topic.arn, message: message)
           end


### PR DESCRIPTION
We're seeing some of these "internal failure" errors on SNS, which is a 500 error.  In general, we should be retrying any errors that are 5XX errors since it's not necessarily and issue with the request itself.

This adds the associated error class to the list of retriable errors.  It also adds a small amount of back-off to the retry block.