### PR TITLE
Fixed processors to use appropriate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Circuitry 3.x.x (TBD)
 
+* Fixed async publisher to use correct configuration options. *Matt Huggins*
 * Fixed issue with `circuitry help` missing dependency. *Matt Huggins*
 * Fixed issue with `circuitry:setup` rake task when no topics are defined. *Matt Huggins*
 * Fixed issues with `circuitry:setup` rake task in vanilla Ruby projects. *Matt Huggins*

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ The `publish` method also accepts options that impact instantiation of the
   will be attempted before giving up. If the timeout is exceeded, an exception
   will raised to be handled by your application or `error_handler`. *(default:
   15)*
+* `:config` - A custom configuration object. Generally this option can be ignored.
+  *(default: `Circuitry.publisher_config`)*
 
 ```ruby
 obj = { foo: 'foo', bar: 'bar' }
@@ -258,6 +260,8 @@ The `subscribe` method also accepts options that impact instantiation of the
   short-polling. *(default: 10)*
 * `:batch_size` - The number of messages to retrieve in a single SQS request.
   *(default: 10)*
+* `:config` - A custom configuration object. Generally this option can be ignored.
+  *(default: `Circuitry.subscriber_config`)*
 
 ```ruby
 options = {

--- a/lib/circuitry.rb
+++ b/lib/circuitry.rb
@@ -7,6 +7,7 @@ require 'circuitry/locks/memory'
 require 'circuitry/locks/noop'
 require 'circuitry/locks/redis'
 require 'circuitry/middleware/chain'
+require 'circuitry/pool'
 require 'circuitry/processor'
 require 'circuitry/processors/batcher'
 require 'circuitry/processors/forker'
@@ -46,9 +47,7 @@ module Circuitry
     end
 
     def flush
-      Processors.constants.each do |const|
-        Processors.const_get(const).flush
-      end
+      Pool.flush
     end
   end
 end

--- a/lib/circuitry/concerns/async.rb
+++ b/lib/circuitry/concerns/async.rb
@@ -24,7 +24,9 @@ module Circuitry
       end
 
       def process_asynchronously(&block)
-        send(:"process_via_#{async}", &block)
+        processor = send(:"process_via_#{async}", &block)
+        processor.process
+        Pool << processor
       end
 
       def async=(value)
@@ -58,15 +60,15 @@ module Circuitry
       end
 
       def process_via_fork(&block)
-        Processors::Forker.process(&block)
+        Processors::Forker.new(config, &block)
       end
 
       def process_via_thread(&block)
-        Processors::Threader.process(&block)
+        Processors::Threader.new(config, &block)
       end
 
       def process_via_batch(&block)
-        Processors::Batcher.process(&block)
+        Processors::Batcher.new(config, &block)
       end
     end
   end

--- a/lib/circuitry/concerns/async.rb
+++ b/lib/circuitry/concerns/async.rb
@@ -17,10 +17,6 @@ module Circuitry
         def async_strategies
           [:fork, :thread, :batch]
         end
-
-        def default_async_strategy
-          raise NotImplementedError, "#{name} must implement class method `default_async_strategy`"
-        end
       end
 
       def process_asynchronously(&block)
@@ -32,7 +28,7 @@ module Circuitry
       def async=(value)
         value = case value
                 when false, nil then false
-                when true then self.class.default_async_strategy
+                when true then config.async_strategy
                 when *self.class.async_strategies then value
                 else raise ArgumentError, async_value_error(value)
                 end

--- a/lib/circuitry/pool.rb
+++ b/lib/circuitry/pool.rb
@@ -1,0 +1,34 @@
+module Circuitry
+  module Pool
+    class << self
+      def <<(processor)
+        raise ArgumentError, 'processor must be a Circuitry::Processor' unless processor.is_a?(Circuitry::Processor)
+        pool << processor
+      end
+
+      def flush
+        while (processor = pool.shift)
+          processor.wait
+        end
+      end
+
+      def size
+        pool.size
+      end
+
+      def empty?
+        pool.empty?
+      end
+
+      def any?
+        pool.any?
+      end
+
+      private
+
+      def pool
+        @pool ||= []
+      end
+    end
+  end
+end

--- a/lib/circuitry/processor.rb
+++ b/lib/circuitry/processor.rb
@@ -1,38 +1,47 @@
 module Circuitry
-  module Processor
-    def process(&_block)
-      raise NotImplementedError, "#{self} must implement class method `process`"
+  class Processor
+    attr_reader :config, :block
+
+    def initialize(config, &block)
+      raise ArgumentError, 'no block given' unless block_given?
+
+      self.config = config
+      self.block = block
     end
 
-    def flush
-      raise NotImplementedError, "#{self} must implement class method `flush`"
+    def process
+      raise NotImplementedError, "#{self} must implement instance method `process`"
     end
 
-    def on_exit
-      Circuitry.subscriber_config.on_async_exit
+    def wait
+      raise NotImplementedError, "#{self} must implement instance method `wait`"
     end
 
     protected
 
-    def safely_process
-      yield
+    def safely_process(&block)
+      block.call
     rescue => e
       logger.error("Error handling message: #{e}")
       error_handler.call(e) if error_handler
-    end
-
-    def pool
-      @pool ||= []
+    ensure
+      on_exit.call if on_exit
     end
 
     private
 
+    attr_writer :config, :block
+
     def logger
-      Circuitry.subscriber_config.logger
+      config.logger
     end
 
     def error_handler
-      Circuitry.subscriber_config.error_handler
+      config.error_handler
+    end
+
+    def on_exit
+      config.on_async_exit
     end
   end
 end

--- a/lib/circuitry/processors/batcher.rb
+++ b/lib/circuitry/processors/batcher.rb
@@ -2,20 +2,13 @@ require 'circuitry/processor'
 
 module Circuitry
   module Processors
-    module Batcher
-      class << self
-        include Processor
+    class Batcher < Processor
+      def process
+        # noop
+      end
 
-        def process(&block)
-          raise ArgumentError, 'no block given' unless block_given?
-          pool << block
-        end
-
-        def flush
-          while (block = pool.shift)
-            safely_process(&block)
-          end
-        end
+      def wait
+        safely_process(&block)
       end
     end
   end

--- a/lib/circuitry/processors/forker.rb
+++ b/lib/circuitry/processors/forker.rb
@@ -2,20 +2,20 @@ require 'circuitry/processor'
 
 module Circuitry
   module Processors
-    module Forker
-      class << self
-        include Processor
+    class Forker < Processor
+      def process
+        Process.detach(pid)
+      end
 
-        def process(&block)
-          pid = fork do
-            safely_process(&block)
-            on_exit.call if on_exit
-          end
+      def wait
+        # noop
+      end
 
-          Process.detach(pid)
-        end
+      private
 
-        def flush
+      def pid
+        @pid ||= fork do
+          safely_process(&block)
         end
       end
     end

--- a/lib/circuitry/processors/threader.rb
+++ b/lib/circuitry/processors/threader.rb
@@ -2,23 +2,20 @@ require 'circuitry/processor'
 
 module Circuitry
   module Processors
-    module Threader
-      class << self
-        include Processor
+    class Threader < Processor
+      def process
+        thread
+      end
 
-        def process(&block)
-          raise ArgumentError, 'no block given' unless block_given?
+      def wait
+        thread.join
+      end
 
-          pool << Thread.new do
-            safely_process(&block)
-            on_exit.call if on_exit
-          end
-        end
+      private
 
-        def flush
-          pool.each(&:join)
-        ensure
-          pool.clear
+      def thread
+        @thread ||= Thread.new do
+          safely_process(&block)
         end
       end
     end

--- a/lib/circuitry/publisher.rb
+++ b/lib/circuitry/publisher.rb
@@ -20,11 +20,12 @@ module Circuitry
       ::Aws::SNS::Errors::InternalFailure
     ].freeze
 
-    attr_reader :timeout
+    attr_reader :config, :timeout
 
     def initialize(options = {})
       options = DEFAULT_OPTIONS.merge(options)
 
+      self.config = options[:config] || Circuitry.publisher_config
       self.async = options[:async]
       self.timeout = options[:timeout]
     end
@@ -41,10 +42,6 @@ module Circuitry
       else
         publish_message(topic_name, message)
       end
-    end
-
-    def self.default_async_strategy
-      Circuitry.publisher_config.async_strategy
     end
 
     protected
@@ -68,13 +65,9 @@ module Circuitry
       end
     end
 
-    def config
-      Circuitry.publisher_config
-    end
-
     private
 
-    attr_writer :timeout
+    attr_writer :config, :timeout
 
     def logger
       config.logger

--- a/lib/circuitry/publisher.rb
+++ b/lib/circuitry/publisher.rb
@@ -68,22 +68,26 @@ module Circuitry
       end
     end
 
-    attr_writer :timeout
+    def config
+      Circuitry.publisher_config
+    end
 
     private
 
+    attr_writer :timeout
+
     def logger
-      Circuitry.publisher_config.logger
+      config.logger
     end
 
     def can_publish?
-      Circuitry.publisher_config.aws_options.values.all? do |value|
+      config.aws_options.values.all? do |value|
         !value.nil? && !value.empty?
       end
     end
 
     def middleware
-      Circuitry.publisher_config.middleware
+      config.middleware
     end
   end
 end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -12,7 +12,7 @@ module Circuitry
     include Concerns::Async
     include Services::SQS
 
-    attr_reader :queue, :timeout, :wait_time, :batch_size, :lock
+    attr_reader :config, :timeout, :wait_time, :batch_size, :lock
 
     DEFAULT_OPTIONS = {
       lock: true,
@@ -30,7 +30,7 @@ module Circuitry
       options = DEFAULT_OPTIONS.merge(options)
 
       self.subscribed = false
-      self.queue = Queue.find(config.queue_name).url
+      self.config = options[:config] || Circuitry.subscriber_config
 
       %i[lock async timeout wait_time batch_size].each do |sym|
         send(:"#{sym}=", options[sym])
@@ -41,35 +41,33 @@ module Circuitry
 
     def subscribe(&block)
       raise ArgumentError, 'block required' if block.nil?
+      raise SubscribeError, 'already subscribed' if subscribed?
       raise SubscribeError, 'AWS configuration is not set' unless can_subscribe?
 
-      logger.info("Subscribing to queue: #{queue}")
-
-      self.subscribed = true
+      subscribed!
       poll(&block)
-      self.subscribed = false
-
-      logger.info("Unsubscribed from queue: #{queue}")
     rescue *CONNECTION_ERRORS => e
       logger.error("Connection error to queue: #{queue}: #{e}")
       raise SubscribeError, e.message
+    ensure
+      unsubscribed!
     end
 
     def subscribed?
       subscribed
     end
 
+    def queue
+      @queue ||= Queue.find(config.queue_name).url
+    end
+
     def self.async_strategies
       super - [:batch]
     end
 
-    def self.default_async_strategy
-      Circuitry.subscriber_config.async_strategy
-    end
-
     protected
 
-    attr_writer :queue, :timeout, :wait_time, :batch_size
+    attr_writer :config, :timeout, :wait_time, :batch_size
     attr_accessor :subscribed
 
     def lock=(value)
@@ -81,10 +79,6 @@ module Circuitry
               end
 
       @lock = value
-    end
-
-    def config
-      Circuitry.subscriber_config
     end
 
     private
@@ -101,6 +95,16 @@ module Circuitry
           self.subscribed = false
         end
       end
+    end
+
+    def subscribed!
+      logger.info("Subscribing to queue: #{queue}") unless subscribed?
+      self.subscribed = true
+    end
+
+    def unsubscribed!
+      logger.info("Unsubscribed from queue: #{queue}") if subscribed?
+      self.subscribed = false
     end
 
     def poll(&block)

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -30,7 +30,7 @@ module Circuitry
       options = DEFAULT_OPTIONS.merge(options)
 
       self.subscribed = false
-      self.queue = Queue.find(Circuitry.subscriber_config.queue_name).url
+      self.queue = Queue.find(config.queue_name).url
 
       %i[lock async timeout wait_time batch_size].each do |sym|
         send(:"#{sym}=", options[sym])
@@ -74,13 +74,17 @@ module Circuitry
 
     def lock=(value)
       value = case value
-              when true then Circuitry.subscriber_config.lock_strategy
+              when true then config.lock_strategy
               when false then Circuitry::Locks::NOOP.new
               when Circuitry::Locks::Base then value
               else raise ArgumentError, lock_value_error(value)
               end
 
       @lock = value
+    end
+
+    def config
+      Circuitry.subscriber_config
     end
 
     private
@@ -183,21 +187,21 @@ module Circuitry
     end
 
     def logger
-      Circuitry.subscriber_config.logger
+      config.logger
     end
 
     def error_handler
-      Circuitry.subscriber_config.error_handler
+      config.error_handler
     end
 
     def can_subscribe?
-      Circuitry.subscriber_config.aws_options.values.all? do |value|
+      config.aws_options.values.all? do |value|
         !value.nil? && !value.empty?
       end
     end
 
     def middleware
-      Circuitry.subscriber_config.middleware
+      config.middleware
     end
   end
 end

--- a/spec/circuitry/concerns/async_spec.rb
+++ b/spec/circuitry/concerns/async_spec.rb
@@ -3,21 +3,9 @@ require 'spec_helper'
 async_class = Class.new do
   include Circuitry::Concerns::Async
 
-  def self.default_async_strategy
-    :thread
-  end
-
   def self.async_strategies
     [:fork, :thread, :batch]
   end
-
-  def config
-    Circuitry.subscriber_config
-  end
-end
-
-incomplete_async_class = Class.new do
-  include Circuitry::Concerns::Async
 
   def config
     Circuitry.subscriber_config
@@ -48,20 +36,8 @@ RSpec.describe Circuitry::Concerns::Async, type: :model do
     end
 
     describe 'with true' do
-      describe 'when the class has defined a default async strategy' do
-        it 'sets async to the default value' do
-          expect(subject.class).to receive(:default_async_strategy).at_least(:once).and_call_original
-          subject.async = true
-          expect(subject.async).to eq subject.class.default_async_strategy
-        end
-      end
-
-      describe 'when the class has not defined a default async strategy' do
-        subject { incomplete_async_class.new }
-
-        it 'raises an error' do
-          expect { subject.async = true }.to raise_error(NotImplementedError)
-        end
+      it 'sets async to the default value' do
+        expect { subject.async = true }.to change { subject.async }.to(subject.config.async_strategy)
       end
     end
 

--- a/spec/circuitry/processor_spec.rb
+++ b/spec/circuitry/processor_spec.rb
@@ -1,43 +1,40 @@
 require 'spec_helper'
 
-processor_class = Class.new do
-  include Circuitry::Processor
-
-  def process(&block)
+processor_class = Class.new(Circuitry::Processor) do
+  def process
     block.call
   end
 
-  def flush
-    pool.clear
+  def wait
+    # noop
   end
 end
 
-incomplete_processor_class = Class.new do
-  include Circuitry::Processor
-end
+incomplete_processor_class = Class.new(Circuitry::Processor)
 
 RSpec.describe Circuitry::Processor, type: :model do
-  subject { processor_class.new }
+  subject { processor_class.new(config, &block) }
 
-  describe '.process' do
-    let(:block) { ->{ } }
+  let(:config) { double('Circuitry::PublisherConfig', logger: nil, error_handler: nil, on_async_exit: nil) }
+  let(:block) { ->{ } }
 
+  describe '#process' do
     describe 'when the class has defined process' do
       it 'raises an error' do
-        expect { subject.process(&block) }.to_not raise_error
+        expect { subject.process }.to_not raise_error
       end
     end
 
     describe 'when the class has not defined process' do
-      subject { incomplete_processor_class.new }
+      subject { incomplete_processor_class.new(config, &block) }
 
       it 'raises an error' do
-        expect { subject.process(&block) }.to raise_error(NotImplementedError)
+        expect { subject.process }.to raise_error(NotImplementedError)
       end
     end
   end
 
-  describe '.safely_process' do
+  describe '#safely_process' do
     def process
       subject.send(:safely_process, &block)
     end
@@ -46,7 +43,7 @@ RSpec.describe Circuitry::Processor, type: :model do
       let(:block) { ->{ raise StandardError } }
 
       before do
-        allow(Circuitry.subscriber_config.logger).to receive(:error)
+        allow(config.logger).to receive(:error)
       end
 
       it 'does not re-raise the error' do
@@ -55,19 +52,19 @@ RSpec.describe Circuitry::Processor, type: :model do
 
       it 'logs an error' do
         process
-        expect(Circuitry.subscriber_config.logger).to have_received(:error)
+        expect(config.logger).to have_received(:error)
       end
 
       describe 'when an error handler is defined' do
         let(:error_handler) { double('Proc', call: true) }
 
         before do
-          allow(Circuitry.subscriber_config).to receive(:error_handler).and_return(error_handler)
+          allow(config).to receive(:error_handler).and_return(error_handler)
         end
 
         it 'handles the error' do
           process
-          expect(Circuitry.subscriber_config.error_handler).to have_received(:call)
+          expect(config.error_handler).to have_received(:call)
         end
       end
 
@@ -76,45 +73,43 @@ RSpec.describe Circuitry::Processor, type: :model do
 
         before do
           allow_message_expectations_on_nil
-          allow(Circuitry.subscriber_config).to receive(:error_handler).and_return(error_handler)
+          allow(config).to receive(:error_handler).and_return(error_handler)
           allow(error_handler).to receive(:call)
         end
 
         it 'does not handle the error' do
           process
-          expect(Circuitry.subscriber_config.error_handler).to_not have_received(:call)
+          expect(config.error_handler).to_not have_received(:call)
         end
       end
     end
 
     describe 'when the block does not raise an error' do
-      let(:block) { ->{ } }
-
       it 'does not log an error' do
-        expect(Circuitry.subscriber_config.logger).to_not receive(:error)
+        expect(config.logger).to_not receive(:error)
         process
       end
 
       it 'does not handle an error' do
         allow_message_expectations_on_nil
-        expect(Circuitry.subscriber_config.error_handler).to_not receive(:call)
+        expect(config.error_handler).to_not receive(:call)
         process
       end
     end
   end
 
-  describe '#flush' do
-    describe 'when the class has defined flush' do
+  describe '#wait' do
+    describe 'when the class has defined wait' do
       it 'does not raise an error' do
-        expect { subject.flush }.to_not raise_error
+        expect { subject.wait }.to_not raise_error
       end
     end
 
-    describe 'when the class has not defined flush' do
-      subject { incomplete_processor_class.new }
+    describe 'when the class has not defined wait' do
+      subject { incomplete_processor_class.new(config, &block) }
 
       it 'raises an error' do
-        expect { subject.flush }.to raise_error(NotImplementedError)
+        expect { subject.wait }.to raise_error(NotImplementedError)
       end
     end
   end

--- a/spec/circuitry/processors/batcher_spec.rb
+++ b/spec/circuitry/processors/batcher_spec.rb
@@ -1,39 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe Circuitry::Processors::Batcher, type: :model do
-  subject { described_class }
+  subject { described_class.new(config, &block) }
+
+  let(:config) { double('Circuitry::PublisherConfig', logger: nil, error_handler: nil, on_async_exit: nil) }
+  let(:block) { -> {} }
 
   it { is_expected.to be_a Circuitry::Processor }
 
-  describe '.batch' do
-    let(:pool) { double('Array', '<<' => []) }
-    let(:block) { -> {} }
-
-    before do
-      allow(subject).to receive(:pool).and_return(pool)
-    end
-
-    it 'adds the block to the pool' do
-      subject.process(&block)
-      expect(pool).to have_received(:<<).with(block)
+  describe '#process' do
+    it 'does not call the block' do
+      expect(block).to_not receive(:call)
+      subject.process
     end
   end
 
-  describe '.flush' do
-    let(:pool) { [-> {}, -> {}] }
-
-    before do
-      allow(subject).to receive(:pool).and_return(pool)
-    end
-
-    it 'calls each block' do
-      subject.flush
-      pool.each { |block| expect(block).to have_received(:call) }
-    end
-
-    it 'clears the pool' do
-      subject.flush
-      expect(pool).to be_empty
+  describe '#wait' do
+    it 'calls the block' do
+      expect(block).to receive(:call)
+      subject.wait
     end
   end
 end

--- a/spec/circuitry/processors/forker_spec.rb
+++ b/spec/circuitry/processors/forker_spec.rb
@@ -1,35 +1,37 @@
 require 'spec_helper'
 
 RSpec.describe Circuitry::Processors::Forker, type: :model do
-  subject { described_class }
+  subject { described_class.new(config, &block) }
+
+  let(:config) { double('Circuitry::PublisherConfig', logger: nil, error_handler: nil, on_async_exit: nil) }
+  let(:block) { ->{ } }
 
   it { is_expected.to be_a Circuitry::Processor }
 
   it_behaves_like 'an asyncronous processor'
 
-  describe '.fork' do
+  describe '#process' do
     before do
       allow(subject).to receive(:fork).and_return(pid)
       allow(Process).to receive(:detach)
     end
 
     let(:pid) { 'pid' }
-    let(:block) { ->{ } }
 
     it 'forks a process' do
-      subject.process(&block)
+      subject.process
       expect(subject).to have_received(:fork)
     end
 
     it 'detaches the forked process' do
-      subject.process(&block)
+      subject.process
       expect(Process).to have_received(:detach).with(pid)
     end
   end
 
-  describe '.flush' do
+  describe '#wait' do
     it 'does nothing' do
-      expect { subject.flush }.to_not raise_error
+      expect { subject.wait }.to_not raise_error
     end
   end
 end

--- a/spec/circuitry_spec.rb
+++ b/spec/circuitry_spec.rb
@@ -58,18 +58,8 @@ RSpec.describe Circuitry, type: :model do
   end
 
   describe '.flush' do
-    it 'flushes batches' do
-      expect(Circuitry::Processors::Batcher).to receive(:flush)
-      subject.flush
-    end
-
-    it 'flushes forks' do
-      expect(Circuitry::Processors::Forker).to receive(:flush)
-      subject.flush
-    end
-
-    it 'flushes threads' do
-      expect(Circuitry::Processors::Threader).to receive(:flush)
+    it 'flushes the pool' do
+      expect(Circuitry::Pool).to receive(:flush)
       subject.flush
     end
   end

--- a/spec/support/examples/async_processor_examples.rb
+++ b/spec/support/examples/async_processor_examples.rb
@@ -6,12 +6,12 @@ RSpec.shared_examples_for 'an asyncronous processor' do
     before do
       allow(subject).to receive(:fork) { |&block| block.call }
       allow(Process).to receive(:detach)
-      allow(Circuitry.subscriber_config).to receive(:on_async_exit).and_return(on_async_exit)
+      allow(config).to receive(:on_async_exit).and_return(on_async_exit)
     end
 
     it 'calls the proc' do
-      subject.process(&block)
-      subject.flush
+      subject.process
+      subject.wait
       expect(on_async_exit).to have_received(:call)
     end
   end


### PR DESCRIPTION
~~This is a WIP, but~~ hoping to get some eyes on it as a fix for #54.

We're currently using the subscriber config for all asynchronous processing, even in spots where we should be using the publisher config.  This changes the behavior and implementation of processors to make them instantiable classes that accept the config they should be working with.  I also introduced a new `Pool` module that is responsible for tracking all async processors and flushing properly.  (Need to add tests for this still.)
