### PR TITLE
Fix rake circuitry:setup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ two methods: the circuitry CLI or the `rake circuitry:setup` task. The rake task
 subscriber queue and publishing topics that are configured within your application.
 
 ```ruby
+require 'circuitry/tasks'
+
 Circuitry.subscriber_config do |c|
   c.queue_name = 'myapp-production-events'
   c.topic_names = ['theirapp-production-stuff-created', 'theirapp-production-stuff-deleted']

--- a/circuitry.gemspec
+++ b/circuitry.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk', '~> 2'
   spec.add_dependency 'retries', '~> 0.0.5'
   spec.add_dependency 'virtus', '~> 1.0'
+  spec.add_dependency 'thor'
 
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'codeclimate-test-reporter'
@@ -34,5 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redis'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
-  spec.add_development_dependency 'thor'
 end

--- a/lib/circuitry/provisioning/provisioner.rb
+++ b/lib/circuitry/provisioning/provisioner.rb
@@ -1,3 +1,4 @@
+require 'circuitry'
 require 'circuitry/provisioning/queue_creator'
 require 'circuitry/provisioning/topic_creator'
 require 'circuitry/provisioning/subscription_creator'

--- a/lib/circuitry/provisioning/subscription_creator.rb
+++ b/lib/circuitry/provisioning/subscription_creator.rb
@@ -26,10 +26,10 @@ module Circuitry
         topics.each do |topic|
           sns.subscribe(topic_arn: topic.arn, endpoint: queue.arn, protocol: 'sqs')
         end
-        sqs.set_queue_attributes(
-          queue_url: queue.url,
-          attributes: build_policy
-        )
+
+        if topics.any?
+          sqs.set_queue_attributes(queue_url: queue.url, attributes: build_policy)
+        end
       end
 
       private

--- a/lib/circuitry/tasks.rb
+++ b/lib/circuitry/tasks.rb
@@ -1,6 +1,7 @@
 namespace :circuitry do
   desc 'Create subscriber queues and subscribe queue to topics'
-  task setup: :environment do
+  task :setup do
+    require 'logger'
     require 'circuitry/provisioning'
 
     logger = Logger.new(STDOUT)


### PR DESCRIPTION
1. Missing requires for `circuitry` and `logger` were added for `rake circuitry:setup` to run in a non-Rails app.
1. Removed `:environment` as a prerequisite task since that only exists in Rails apps and isn't needed.
1. We now check if `topics` are configured during provisioning before creating a policy since attempting to add a policy with no topics results in an AWS error being thrown.
1. The `thor` gem needs to be a runtime dependency (rather than development dependency) in order for `circuitry help provision` to work.
1. Added a line to README that demonstrates how to include circuitry rake tasks in your project.