### PR TITLE
Fixed rails environment loading for setup rake task

### DIFF
--- a/lib/circuitry/tasks.rb
+++ b/lib/circuitry/tasks.rb
@@ -9,4 +9,8 @@ namespace :circuitry do
 
     Circuitry::Provisioning.provision(logger: logger)
   end
+
+  if Rake::Task.task_defined?(:environment)
+    task setup: :environment
+  end
 end


### PR DESCRIPTION
When I removed the `:environment` task dependency as [part of this commit](https://github.com/kapost/circuitry/pull/56/commits/66408fc852240f74dbe6ffcf7ac1857a9ac63e5d), it fixed the task for pure Ruby apps, but it prevented initializers from loading in Rails apps.  Since an initializer is the likely place that the circuitry configuration is defined, it's important that we run that task in order to look at the proper AWS config, queue name, topics, etc.

*TODO: test this in plain Ruby and Rails apps before merging/releasing.*