### PR TITLE
Allow option to use IAM instance profile credentials

### DIFF
--- a/lib/circuitry/config/shared_settings.rb
+++ b/lib/circuitry/config/shared_settings.rb
@@ -9,6 +9,7 @@ module Circuitry
         base.attribute :access_key, String
         base.attribute :secret_key, String
         base.attribute :region, String, default: 'us-east-1'
+        base.attribute :use_iam_profile, Virtus::Attribute::Boolean, default: false
         base.attribute :logger, Logger, default: Logger.new(STDERR)
         base.attribute :error_handler
         base.attribute :topic_names, Array[String], default: []

--- a/lib/circuitry/publisher.rb
+++ b/lib/circuitry/publisher.rb
@@ -77,6 +77,8 @@ module Circuitry
     end
 
     def can_publish?
+      return true if Circuitry.publisher_config.use_iam_profile
+
       Circuitry.publisher_config.aws_options.values.all? do |value|
         !value.nil? && !value.empty?
       end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -191,6 +191,8 @@ module Circuitry
     end
 
     def can_subscribe?
+      return true if Circuitry.subscriber_config.use_iam_profile
+
       Circuitry.subscriber_config.aws_options.values.all? do |value|
         !value.nil? && !value.empty?
       end


### PR DESCRIPTION
This is done entirely in the AWS SDK, and requires no work on the gem's part.
