### PR TITLE
Fixed environment rake task invokation for circuitry:setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Circuitry 3.1.6 (Nov 21, 2016)
+
+* Fixed `environment` prerequisite task for `circuitry:setup` when using a more recent version
+  of rake. *Matt Huggins*
+
+## Circuitry 3.1.5 (May 4, 2016)
+
+* Added optional `environment` prerequisite to `circuitry:setup` rake task. *Matt Huggins*
+
 ## Circuitry 3.1.4 (Apr 21, 2016)
 
 * Fixed issue with `circuitry help` missing dependency. *Matt Huggins*

--- a/circuitry.gemspec
+++ b/circuitry.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
 
   spec.add_development_dependency 'bundler', '~> 1.8'
-  spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'connection_pool'
   spec.add_development_dependency 'dalli'
   spec.add_development_dependency 'memcache_mock'

--- a/lib/circuitry/tasks.rb
+++ b/lib/circuitry/tasks.rb
@@ -7,10 +7,10 @@ namespace :circuitry do
     logger = Logger.new(STDOUT)
     logger.level = Logger::INFO
 
-    Circuitry::Provisioning.provision(logger: logger)
-  end
+    if Rake::Task.task_defined?(:environment)
+      Rake::Task[:environment].invoke
+    end
 
-  if Rake::Task.task_defined?(:environment)
-    task setup: :environment
+    Circuitry::Provisioning.provision(logger: logger)
   end
 end

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '3.1.5'
+  VERSION = '3.1.6'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'circuitry'


### PR DESCRIPTION
This fixes an issue with the Rails `environment` rake task not being executed before `circuitry:setup` in newer versions of rake.  /cc @BlueVajra this is what you ran into recently as well.