### PR TITLE
Handle single message response from AWS

### DIFF
--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -107,6 +107,7 @@ module Circuitry
       end
 
       poller.poll(max_number_of_messages: batch_size, wait_time_seconds: wait_time, skip_delete: true) do |messages|
+        messages = [messages] unless messages.is_a?(Array)
         process_messages(Array(messages), &block)
         Circuitry.flush
       end


### PR DESCRIPTION
`Aws::SQS::Types::Message` returns different responses as `messages` depending on `batch_size`.

For a `batch_size` of 1, AWS returns
```
{
  :message_id => "one",
  :receipt_handle => "test receipt handle",
  :md5_of_body => "test md5",
   :body => "text for body",
  :attributes => {
    "SenderId" => "sender123",
  "ApproximateFirstReceiveTimestamp" => "1493921572480",
  "ApproximateReceiveCount" => "2",
    "SentTimestamp" => "1493921111028"
  },
  :md5_of_message_attributes => nil,
  :message_attributes => {}
}
```

which has problems when cast to an `Array`.
```
[
  [0] "one",
  [1] "test receipt handle",
  [2] "test md5",
  [3] "text for body",
  [4] {
                              "SenderId" => "sender123",
      "ApproximateFirstReceiveTimestamp" => "1493921572480",
               "ApproximateReceiveCount" => "2",
                         "SentTimestamp" => "1493921111028"
  },
  [5] nil,
  [6] {}
]
```

For a `batch_size` of more than 1, AWS returns an appropriate `Array`.

The deeper issue may be AWS's `Aws::Structure` class, but this PR implements an immediate fix by checking for the [`messages` class](https://github.com/kapost/circuitry/blob/master/lib/circuitry/subscriber.rb#L109).