### PR TITLE
readme for 'Allow option to use IAM instance profile credentials'

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,15 @@ production:
 Available configuration options for *both* subscriber and publisher applications include:
 
 * `access_key`: The AWS access key ID that has access to SNS publishing and/or
-  SQS subscribing. *(required)*
+  SQS subscribing. *(required unless using iam profile)*
 * `secret_key`: The AWS secret access key that has access to SNS publishing
-  and/or SQS subscribing. *(required)*
+  and/or SQS subscribing. *(required unless using iam profile)*
+* `use_iam_profile`: Whether or not to use an iam profile for authenticating to AWS.
+  This will only work when running your application inside of an AWS instance.
+  Accepts `true` or `false`
+  Please refer to the [AWS Docs](http://docs.aws.amazon.com/sdk-for-ruby/v2/developer-guide/setup-config.html#aws-ruby-sdk-credentials-iam)
+  for more details about using iam profiles for authentication.
+  *(required unless using access and secret keys, default: `false`)*
 * `region`: The AWS region that your SNS and/or SQS account lives in.
   *(optional, default: "us-east-1")*
 * `logger`: The logger to use for informational output, warnings, and error

--- a/lib/circuitry/config/shared_settings.rb
+++ b/lib/circuitry/config/shared_settings.rb
@@ -9,6 +9,7 @@ module Circuitry
         base.attribute :access_key, String
         base.attribute :secret_key, String
         base.attribute :region, String, default: 'us-east-1'
+        base.attribute :use_iam_profile, Virtus::Attribute::Boolean, default: false
         base.attribute :logger, Logger, default: Logger.new(STDERR)
         base.attribute :error_handler
         base.attribute :topic_names, Array[String], default: []

--- a/lib/circuitry/publisher.rb
+++ b/lib/circuitry/publisher.rb
@@ -77,6 +77,8 @@ module Circuitry
     end
 
     def can_publish?
+      return true if Circuitry.publisher_config.use_iam_profile
+
       Circuitry.publisher_config.aws_options.values.all? do |value|
         !value.nil? && !value.empty?
       end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -192,6 +192,8 @@ module Circuitry
     end
 
     def can_subscribe?
+      return true if Circuitry.subscriber_config.use_iam_profile
+
       Circuitry.subscriber_config.aws_options.values.all? do |value|
         !value.nil? && !value.empty?
       end


### PR DESCRIPTION
This is just to add some documentation for the `use_iam_profile` option as requested in #61 