### PR TITLE
Change the "Publishing message.." log message to debug vs info

### DIFF
--- a/lib/circuitry/publisher.rb
+++ b/lib/circuitry/publisher.rb
@@ -54,7 +54,7 @@ module Circuitry
         # TODO: Don't use ruby timeout.
         # http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/
         Timeout.timeout(timeout) do
-          logger.info("Publishing message to #{topic_name}")
+          logger.debug("Publishing message to #{topic_name}")
 
           handler = ->(error, attempt_number, _total_delay) do
             logger.warn("Error publishing attempt ##{attempt_number}: #{error.class} (#{error.message}); retrying...")

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -179,7 +179,7 @@ module Circuitry
     end
 
     def delete_message(message)
-      logger.info("Removing message #{message.id} from queue")
+      logger.debug("Removing message #{message.id} from queue")
       sqs.delete_message(queue_url: queue, receipt_handle: message.receipt_handle)
     end
 

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -132,7 +132,7 @@ module Circuitry
     def process_message(message, &block)
       message = Message.new(message)
 
-      logger.info("Processing message #{message.id}")
+      logger.debug("Processing message #{message.id}")
 
       handled = try_with_lock(message.id) do
         handle_message_with_middleware(message, &block)


### PR DESCRIPTION
This message creates a ton of info level logs, since, unlike the other info level log entries (queue subscribe, queue unsubscribe, etc), there is one log entry per message published.

In thinking about how to categorize log entries, I really like looking to Java's log4j, which defines info and debug as follows:

- **Debug:** Designates fine-grained informational events that are most useful to debug an application.
- **Info:** Designates informational messages that highlight the progress of the application at coarse-grained level.

I propose that any per-message log entries should be logged at a debug level, to better conform to the definitions above, and so as not to generate tons of logs in a production system.