### PR TITLE
Version 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## Unreleased
+## Circuitry 3.3.0 (June 23, 2020)
 
 * Update AWS SDK to version 3 and use module sdk gems. *thogg4*
+  See https://github.com/aws/aws-sdk-ruby 
+  Version 3 is backwards compatible with version 2.
+* Catch `Aws::SNS::Errors::InvalidParameter` and rethrow with the topic
+  and message that caused the problem for improved debugging.
 
 ## Circuitry 3.2.0 (May 6, 2017)
 

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '3.2.0'
+  VERSION = '3.3.0'
 end

--- a/spec/circuitry/publisher_spec.rb
+++ b/spec/circuitry/publisher_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Circuitry::Publisher, type: :model do
       describe 'when AWS credentials are set' do
         before do
           allow(Circuitry.publisher_config).to receive(:aws_options).and_return(access_key_id: 'key', secret_access_key: 'secret', region: 'region')
+          allow(logger).to receive(:debug)
         end
 
         shared_examples_for 'a valid publish request' do

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Circuitry::Subscriber, type: :model do
 
       before do
         allow(Circuitry.subscriber_config).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:debug)
         allow(subject).to receive(:sqs).and_return(mock_sqs)
         allow(Aws::SQS::QueuePoller).to receive(:new).with(queue, client: mock_sqs).and_return(mock_poller)
 


### PR DESCRIPTION
### Overview
* When published, will official release https://github.com/kapost/circuitry/pull/70/commits.
  Tested it locally with other Kapost apps that use circuitry and worked fine.
* Improve error message when the sqs message is invalid, for example too large. The
  exception will have the actual message available so we can debug the source.
