### PR TITLE
Bump gem version to `3.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Circuitry 3.4.0 Sep 16, 2020)
 
 * Adds an option for publisher and subscriber configs to override the AWS client options. *wahlg*
   See: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '3.3.0'
+  VERSION = '3.4.0'
 end


### PR DESCRIPTION
### Overview
- Officially releases https://github.com/kapost/circuitry/pull/80
  which adds `aws_options_overrides` to aws clients
- I went with a minor version since it's an enhancement.