### PR TITLE
changes policy creation to avoid statement limit of 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/circuitry
     docker:
-      - image: kapost/ruby:2.4.3-node-6.11.5
+      - image: kapost/ruby:2.6.3-node-6.11.5
     steps:
       - checkout
       - run: bundle install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Circuitry 3.4.0 Sep 16, 2020)
+## Circuitry 3.5.0 (Jan 27, 2023)
+
+* Changes the way SQL Policy statements are generated to avoid triggering an error when more a
+  queue subscribes to more than 20 SNS topics.
+
+## Circuitry 3.4.0 (Sep 16, 2020)
 
 * Adds an option for publisher and subscriber configs to override the AWS client options. *wahlg*
   See: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in circuitry.gemspec
 gemspec
 
-gem 'memcache_mock', '0.0.14', github: 'mhuggins/MemcacheMock', branch: 'expiry-and-add'
+gem 'memcache_mock', '0.0.14', git: 'https://github.com/mhuggins/MemcacheMock', branch: 'expiry-and-add'

--- a/circuitry.gemspec
+++ b/circuitry.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0'
   spec.add_dependency 'thor'
 
-  spec.add_development_dependency 'bundler', '~> 1.8'
+  spec.add_development_dependency 'bundler', '~> 1.17.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'connection_pool'
   spec.add_development_dependency 'dalli'

--- a/lib/circuitry/provisioning/subscription_creator.rb
+++ b/lib/circuitry/provisioning/subscription_creator.rb
@@ -43,12 +43,12 @@ module Circuitry
           'Policy' => {
             'Version'   => '2012-10-17',
             'Id'        => "#{queue.arn}/SNSPolicy",
-            'Statement' => [build_policy_statement]#topics.map { |t| build_policy_statement(t) }
+            'Statement' => [build_policy_statement]
           }.to_json
         }
       end
 
-      def build_policy_statement#(topic)
+      def build_policy_statement
         {
           'Sid'       => "Sid-#{queue.name}-subscriptions",
           'Effect'    => 'Allow',

--- a/lib/circuitry/provisioning/subscription_creator.rb
+++ b/lib/circuitry/provisioning/subscription_creator.rb
@@ -43,20 +43,20 @@ module Circuitry
           'Policy' => {
             'Version'   => '2012-10-17',
             'Id'        => "#{queue.arn}/SNSPolicy",
-            'Statement' => topics.map { |t| build_policy_statement(t) }
+            'Statement' => [build_policy_statement]#topics.map { |t| build_policy_statement(t) }
           }.to_json
         }
       end
 
-      def build_policy_statement(topic)
+      def build_policy_statement#(topic)
         {
-          'Sid'       => "Sid#{topic.name}",
+          'Sid'       => "Sid-#{queue.name}-subscriptions",
           'Effect'    => 'Allow',
           'Principal' => { 'AWS' => '*' },
           'Action'    => 'SQS:SendMessage',
           'Resource'  => queue.arn,
           'Condition' => {
-            'ArnEquals' => { 'aws:SourceArn' => topic.arn }
+            'ForAnyValue:ArnEquals' => { 'aws:SourceArn' => topics.map(&:arn) }
           }
         }
       end

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '3.4.0'
+  VERSION = '3.5.0'
 end


### PR DESCRIPTION
SQS Policies have a limit on the amount of Statements they can have which is 20. Presently we are creating a statement per policy this changes that behavior to instead use `ForAnyValue:ArnEquals` and generate a single Statement with all the topics included in it.